### PR TITLE
Replace faraday middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ rvm:
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode
-  - rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circuitbox.gemspec
 gemspec
 
-gem 'terminal-notifier-guard', group: :test 
+group :test do
+  gem "terminal-notifier-guard"
+  gem "pry"
+end
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ end
 
 ```
 
-## Faraday (Caveat: Open circuits return a nil response object)
+## Faraday
 
 Circuitbox ships with [Faraday HTTP client](https://github.com/lostisland/faraday) middleware.
 
@@ -133,19 +133,31 @@ Circuitbox ships with [Faraday HTTP client](https://github.com/lostisland/farada
 require 'faraday'
 require 'circuitbox/faraday_middleware'
 
-conn = Faraday::Connection.new(:url => "http://example.com") do |builder|
-  builder.use Circuitbox::FaradayMiddleware
+conn = Faraday.new(:url => "http://example.com") do |c|
+  c.use Circuitbox::FaradayMiddleware
 end
 
-if response = conn.get("/api")
+response = conn.get("/api")
+if response.success?
   # success
 else
   # failure or open circuit
 end
 ```
 
+By default the Faraday middleware returns a `503` response when the circuit is
+open, but this as many other things can be configured via middleware options
+
+* `exceptions` pass a list of exceptions for the Circuitbreaker to catch,
+  defaults to Timeout and Request failures
+* `default_value` value to return for open circuits, defaults to 503 response
+* `identifier` circuit id, defaults to request url
+* `circuit_breaker_run_options` options passed to the circuit run method
+* `circuit_breaker_options` options to initialize the circuit with defaults to
+  `{ volume_threshold: 10, exceptions: Circuitbox::FaradayMiddleware::DEFAULT_EXCEPTIONS }`
+
 ## TODO
-* Fix Faraday integration to return a Faraday response object
+* ~~Fix Faraday integration to return a Faraday response object~~
 * Split stats into it's own repository
 * Circuit Breaker should raise an exception by default instead of returning nil
 * Refactor to use single state variable

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rack"
   spec.add_development_dependency "guard-minitest"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "gimme"

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -2,30 +2,77 @@ require 'faraday'
 require 'circuitbox'
 
 class Circuitbox
-  class RequestError < StandardError; end
+  class FaradayMiddleware < Faraday::Middleware
+    class RequestFailed < StandardError ; end
 
-  class FaradayMiddleware < Faraday::Response::Middleware
+    DEFAULT_EXCEPTIONS = [
+      Faraday::Error::TimeoutError,
+      RequestFailed,
+    ]
 
-    attr_accessor :identifier, :exceptions
+    class NullResponse < Faraday::Response
+      def initialize
+        super(status: 503, response_headers: {})
+      end
+    end
 
-    def initialize(app, opts={})
-      @identifier = opts.fetch(:identifier) { ->(env) { env.url }}
-      @exceptions = opts.fetch(:exceptions) { [Faraday::Error::TimeoutError] }
+    attr_reader :opts
+
+    def initialize(app, opts = {})
+      @app = app
+      @opts = opts
       super(app)
     end
 
-    def call(env)
-      id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
-      circuit = Circuitbox.circuit id, :exceptions => exceptions
-      circuit.run do
-        super(env)
+    def call(request_env)
+      response = circuit(request_env).run(run_options(request_env)) do
+        @app.call(request_env).on_complete do |response_env|
+          raise RequestFailed unless response_env.success?
+        end
       end
+
+      response.nil? ? circuit_open_value(request_env) : response
     end
 
-    def on_complete(env)
-      if !env.success?
-        raise RequestError
-      end
+    def exceptions
+      circuit_breaker_options[:exceptions]
+    end
+
+    def identifier
+      @identifier ||= opts.fetch(:identifier, ->(env) { env[:url] })
+    end
+
+    private
+
+    def run_options(env)
+      env[:circuit_breaker_run_options] || {}
+    end
+
+    def circuit_breaker_options
+      return @circuit_breaker_options if @current_adapter
+
+      @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
+      @circuit_breaker_options.merge!(
+        exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS),
+        volume_threshold: 10
+      )
+    end
+
+    def default_value
+      @default_value ||= opts.fetch(:default_value, NullResponse.new)
+    end
+
+    def circuitbox
+      @circuitbox ||= opts.fetch(:circuitbox, Circuitbox)
+    end
+
+    def circuit_open_value(env)
+      env[:circuit_breaker_default_value] || default_value
+    end
+
+    def circuit(env)
+      id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
+      circuitbox.circuit id, circuit_breaker_options
     end
   end
 end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'circuitbox'
 require 'ostruct'
 
 class CircuitBreakerTest < Minitest::Test

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'circuitbox'
 
 class Circuitbox::ExampleStore < ActiveSupport::Cache::MemoryStore; end
 

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -1,0 +1,33 @@
+require "integration_helper"
+
+class Circuitbox
+  class FaradayMiddlewareTest < Minitest::Test
+    @@only_once = false
+    def setup
+      @connection = Faraday.new do |c|
+        c.use FaradayMiddleware
+        c.adapter Faraday.default_adapter
+      end
+      @success_url = "http://localhost:4711"
+      @failure_url = "http://localhost:4712"
+
+      if !@@only_once
+        FakeServer.create(4711, ['200', {'Content-Type' => 'text/plain'}, ["Success!"]])
+        FakeServer.create(4712, ['500', {'Content-Type' => 'text/plain'}, ["Failure!"]])
+      end
+    end
+
+    def teardown
+      Circuitbox.reset
+    end
+
+    def test_open_circuit_response
+      10.times { @connection.get(@failure_url) } # make the CircuitBreaker open
+      assert @connection.get(@failure_url).status, 503
+    end
+
+    def test_closed_circuit_response
+      assert @connection.get(@success_url).success?
+    end
+  end
+end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+require "faraday"
+require "circuitbox/faraday_middleware"
+require "rack"
+
+class FakeServer
+  def self.instance
+    @@instance ||= FakeServer.new
+    # if the FakeServer is used kill all of them after the tests are done
+    Minitest.after_run { FakeServer.shutdown }
+    @@instance
+  end
+
+  def initialize
+    @servers = []
+  end
+
+  def self.create(port, result)
+    FakeServer.instance.create(port, result)
+  end
+
+  def self.shutdown
+    FakeServer.instance.shutdown
+  end
+
+  def shutdown
+    @servers.map { |server| server.exit }
+    @servers = []
+  end
+
+  def create(port, result)
+    @servers << Thread.new do
+      Rack::Handler::WEBrick.run(Proc.new { |env| result },
+                                 Port: port,
+                                 AccessLog: [],
+                                 Logger: WEBrick::Log.new(DEV_NULL))
+    end
+    sleep 0.5 # wait for the server to spin up
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,15 @@
-require 'minitest'
 require 'minitest/autorun'
-require 'minitest/pride'
 require 'mocha/mini_test'
 require 'timecop'
 require 'gimme'
+require 'circuitbox'
+
+DEV_NULL = (RUBY_PLATFORM =~ /mswin|mingw/ ? "NUL" : "/dev/null")
+
+class Circuitbox
+  class CircuitBreaker
+    def logger
+      @_dev_null_logger ||= Logger.new(DEV_NULL)
+    end
+  end
+end


### PR DESCRIPTION
the previous verison of the `faraday_middleware` was lacking in a lot of ways.
This new verison provides mostly the same interface but is much more
configurabel with sane defaults

- return a Faraday Response by default for an open circuit, not `nil`
  to make the client side handling easier
- allow passing the `circuit_breaker_options`
- allow passing the `circuit_breaker_run_options`
- allow setting a static return value for the case of the open circuit