### PR TITLE
keep response on circuit open in middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
-  - jruby-20mode
-  - jruby-21mode

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circuitbox.gemspec
 gemspec
 
-group :test do
-  gem "terminal-notifier-guard"
-  gem "pry"
-end
-

--- a/README.md
+++ b/README.md
@@ -150,11 +150,40 @@ open, but this as many other things can be configured via middleware options
 
 * `exceptions` pass a list of exceptions for the Circuitbreaker to catch,
   defaults to Timeout and Request failures
+
+```ruby
+c.use Circuitbox::FaradayMiddleware, exceptions: [Faraday::Error::TimeoutError]
+```
+
 * `default_value` value to return for open circuits, defaults to 503 response
+  wrapping the original response given by the service and stored as
+  `original_response` property of the returned 503, this can be overwritten
+  either with a static value or a `lambda` which is passed the
+  original_response.
+
+```ruby
+c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response| ... }
+```
+
 * `identifier` circuit id, defaults to request url
-* `circuit_breaker_run_options` options passed to the circuit run method
+
+```ruby
+c.use Circuitbox::FaradayMiddleware, identifier: "service_name_circuit"
+```
+
+* `circuit_breaker_run_options` options passed to the circuit run method, see
+  the main circuitbreaker for those.
+
+```ruby
+conn.get("/api", circuit_breaker_run_options: {})
+```
+
 * `circuit_breaker_options` options to initialize the circuit with defaults to
   `{ volume_threshold: 10, exceptions: Circuitbox::FaradayMiddleware::DEFAULT_EXCEPTIONS }`
+
+```ruby
+c.use Circuitbox::FaradayMiddleware, circuit_breaker_options: {}
+```
 
 ## TODO
 * ~~Fix Faraday integration to return a Faraday response object~~

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -9,7 +9,6 @@ class Circuitbox
     attr_reader :app
     def setup
       @app = gimme
-      give(@app).run { :run }
     end
 
     def test_default_identifier
@@ -20,6 +19,25 @@ class Circuitbox
     def test_overwrite_identifier
       middleware = FaradayMiddleware.new(app, identifier: "sential")
       assert_equal middleware.identifier, "sential"
+    end
+
+    def test_overwrite_default_value_generator_lambda
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuitbox).circuit("url", anything) { circuit }
+      default_value_generator = lambda { |_| :sential }
+      middleware = FaradayMiddleware.new(app,
+                                         circuitbox: circuitbox,
+                                         default_value: default_value_generator)
+      assert_equal middleware.call(env), :sential
+    end
+
+    def test_overwrite_default_value_generator_static_value
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuitbox).circuit("url", anything) { circuit }
+      middleware = FaradayMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
+      assert_equal middleware.call(env), :sential
     end
 
     def test_default_exceptions

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -23,11 +23,14 @@ class Circuitbox
 
     def test_open_circuit_response
       10.times { @connection.get(@failure_url) } # make the CircuitBreaker open
-      assert @connection.get(@failure_url).status, 503
+      open_circuit_response = @connection.get(@failure_url)
+      assert open_circuit_response.status, 503
+      assert_match open_circuit_response.original_response.body, "Failure!"
     end
 
     def test_closed_circuit_response
-      assert @connection.get(@success_url).success?
+      result = @connection.get(@success_url)
+      assert result.success?
     end
   end
 end


### PR DESCRIPTION
before the response returned in case of an error was thrown away when the
circuit opened, now it is wrapped in the null response so we can do something
with it, alternativly they way the default response is generated is no longer
static but a lambda which is passed the response from the circuit.

fixes #10