### PR TITLE
Add run! method to support raising exceptions from a circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ class ExampleServiceClient
 end
 ```
 
+Using the `run!` method will throw an exception when the circuit is open or the underlying service fails.
+
+```ruby
+  def http_get
+    circuit.run! do
+      Zephyr.new("http://example.com").get(200, 1000, "/api/messages")
+    end
+  end
+```
+
+
 ## Configuration
 
 ```ruby
@@ -188,7 +199,7 @@ c.use Circuitbox::FaradayMiddleware, circuit_breaker_options: {}
 ## TODO
 * ~~Fix Faraday integration to return a Faraday response object~~
 * Split stats into it's own repository
-* Circuit Breaker should raise an exception by default instead of returning nil
+* ~~Circuit Breaker should raise an exception by default instead of returning nil~~
 * Refactor to use single state variable
 * Fix the partition hack
 * Integrate with Breakerbox/Hystrix

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -3,11 +3,15 @@ require 'active_support'
 require 'logger'
 require 'timeout'
 
-require "circuitbox/version"
+require 'circuitbox/version'
 require 'circuitbox/memcache_store'
 require 'circuitbox/railtie' if defined?(Rails)  
 require 'circuitbox/circuit_breaker'
 require 'circuitbox/notifier'
+
+require 'circuitbox/errors/error'
+require 'circuitbox/errors/open_circuit_error'
+require 'circuitbox/errors/service_failure_error'
 
 class Circuitbox
   attr_accessor :circuits, :circuit_store, :stat_store

--- a/lib/circuitbox/errors/error.rb
+++ b/lib/circuitbox/errors/error.rb
@@ -1,0 +1,4 @@
+class Circuitbox
+  class Error < StandardError
+  end
+end

--- a/lib/circuitbox/errors/open_circuit_error.rb
+++ b/lib/circuitbox/errors/open_circuit_error.rb
@@ -1,0 +1,10 @@
+class Circuitbox
+  class OpenCircuitError < Circuitbox::Error
+    attr_reader :service
+
+    def initialize(service)
+      @service = service
+    end
+
+  end
+end

--- a/lib/circuitbox/errors/service_failure_error.rb
+++ b/lib/circuitbox/errors/service_failure_error.rb
@@ -1,0 +1,11 @@
+class Circuitbox
+  class ServiceFailureError < Circuitbox::Error
+    attr_reader :service, :original
+
+    def initialize(service, exception)
+      @service = service
+      @original = exception
+    end
+
+  end
+end


### PR DESCRIPTION
Really like this gem, but for our use case, we needed circuits to throw exceptions when problems occur:

* `run!` method added to CircuitBreaker; implementation changed to throw exceptions rather than returning nil
* existing behaviour of `run` has been maintained