### PR TITLE
Kill cached response

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,26 @@ conn.get("/api", circuit_breaker_run_options: {})
 c.use Circuitbox::FaradayMiddleware, circuit_breaker_options: {}
 ```
 
+<<<<<<< HEAD
 * `open_circuit` lambda determining what response is considered a failure, 
   counting towards the opening of the circuit
 
 ```ruby
 c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.status >= 500 }
 ```
+## CHANGELOG
+### version next
+
+### v0.10
+- configuration option for faraday middleware for what should be considered to open the circuit [enrico-scalavio](https://github.com/enrico-scalavino)
+- fix for issue 16, support of in_parallel requests in faraday middlware which were opening the circuit.
+
+### v0.9
+- deprecate the __run_option__ `:storage_key`
+
+### v0.8
+- 0.8 add `run!` method to raise exception on circuit open and service
+    errors.
 
 ## TODO
 * ~~Fix Faraday integration to return a Faraday response object~~
@@ -224,15 +238,6 @@ And then execute:
 Or install it yourself as:
 
     $ gem install circuitbox
-
-## Changes
-
-### version next
-- configuration option for faraday middleware for what should be considered to open the circuit [enrico-scalavio](https://github.com/enrico-scalavino)
-- fix for issue 16, support of in_parallel requests in faraday middlware which were opening the circuit.
-
-### 0.9.0
-- Everything released, as we did not keep a changelog prior
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -204,26 +204,19 @@ c.use Circuitbox::FaradayMiddleware, circuit_breaker_options: {}
 c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.status >= 500 }
 ```
 ## CHANGELOG
+<<<<<<< HEAD
 ### version next
 
 ### v0.10
 - configuration option for faraday middleware for what should be considered to open the circuit [enrico-scalavio](https://github.com/enrico-scalavino)
 - fix for issue 16, support of in_parallel requests in faraday middlware which were opening the circuit.
-
-### v0.9
 - deprecate the __run_option__ `:storage_key`
 
-### v0.8
-- 0.8 add `run!` method to raise exception on circuit open and service
-    errors.
+### v0.9
+- add `run!` method to raise exception on circuit open and service
 
-## TODO
-* ~~Fix Faraday integration to return a Faraday response object~~
-* Split stats into it's own repository
-* ~~Circuit Breaker should raise an exception by default instead of returning nil~~
-* Refactor to use single state variable
-* Fix the partition hack
-* Integrate with Breakerbox/Hystrix
+### v0.8
+- Everything prior to keeping the change log
 
 ## Installation
 

--- a/lib/circuitbox/version.rb
+++ b/lib/circuitbox/version.rb
@@ -1,3 +1,3 @@
 class Circuitbox
-VERSION='0.9.0'
+VERSION='0.10.0'
 end


### PR DESCRIPTION
This is not the responsibility of circuitbox to return a cached response when the request fail on a opened circuit. Lets remove this.

I'm also so happy to remove a hacked feature that had no test coverage !!!!

@sideshowcoder please review.