### PR TITLE
Change warning to warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class CircuitOpenException    < StandardError ; end
 
 ActiveSupport::Notifications.subscribe('circuit_open') do |name, start, finish, id, payload|
   circuit_name = payload[:circuit]
-  Rails.logger.warning("Open circuit for: #{circuit_name}")
+  Rails.logger.warn("Open circuit for: #{circuit_name}")
 end
 ActiveSupport::Notifications.subscribe('circuit_close') do |name, start, finish, id, payload|
   circuit_name = payload[:circuit]


### PR DESCRIPTION
Under notifications section:

Rails.logger.warning("Open circuit for: #{circuit_name}")

Should be

Rails.logger.warn("Open circuit for: #{circuit_name}")

(there is no warning method on rails logger)