### PR TITLE
Middleware: Provide more information to default_value handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.
 
 ### version next
 
-- **Breaking change** Faraday middleware passes two arguments to the default
+- Faraday middleware passes two arguments to the `default_value`
   callback, not just one.  First argument is still the error response from
   Faraday if there is one.  Second argument is the exception that caused the
-  call to fail if it failed before Faraday returned a response.
+  call to fail if it failed before Faraday returned a response.  Old behaviour
+  is preserved if you pass a lambda that takes just one argument.
 
 ### v0.10.1
 - [Documentation fix](https://github.com/yammer/circuitbox/pull/29) [chiefcll](https://github.com/chiefcll)

--- a/README.md
+++ b/README.md
@@ -169,11 +169,15 @@ c.use Circuitbox::FaradayMiddleware, exceptions: [Faraday::Error::TimeoutError]
 * `default_value` value to return for open circuits, defaults to 503 response
   wrapping the original response given by the service and stored as
   `original_response` property of the returned 503, this can be overwritten
-  either with a static value or a `lambda` which is passed the
-  original_response.
+  with either
+  * a static value
+  * a `lambda` which is passed the `original_response` and `original_error`.
+    `original_response` will be populated if Faraday returne an error response,
+    `original_error` will be populated if an error was thrown before Faraday
+    returned a response.
 
 ```ruby
-c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response| ... }
+c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response, error| ... }
 ```
 
 * `identifier` circuit id, defaults to request url
@@ -206,6 +210,11 @@ c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.
 ## CHANGELOG
 
 ### version next
+
+- **Breaking change** Faraday middleware passes two arguments to the default
+  callback, not just one.  First argument is still the error response from
+  Faraday if there is one.  Second argument is the exception that caused the
+  call to fail if it failed before Faraday returned a response.
 
 ### v0.10.1
 - [Documentation fix](https://github.com/yammer/circuitbox/pull/29) [chiefcll](https://github.com/chiefcll)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ c.use Circuitbox::FaradayMiddleware, exceptions: [Faraday::Error::TimeoutError]
   * a `lambda` which is passed the `original_response` and `original_error`.
     `original_response` will be populated if Faraday returne an error response,
     `original_error` will be populated if an error was thrown before Faraday
-    returned a response.
+    returned a response.  (It will also accept a lambda with arity 1 that is
+    only passed `original_response`.  This use is deprecated and will be removed
+    in the next major version.)
 
 ```ruby
 c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response, error| ... }
@@ -215,7 +217,8 @@ c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.
   callback, not just one.  First argument is still the error response from
   Faraday if there is one.  Second argument is the exception that caused the
   call to fail if it failed before Faraday returned a response.  Old behaviour
-  is preserved if you pass a lambda that takes just one argument.
+  is preserved if you pass a lambda that takes just one argument, but this is
+  deprecated and will be removed in the next version of Circuitbox.
 
 ### v0.10.1
 - [Documentation fix](https://github.com/yammer/circuitbox/pull/29) [chiefcll](https://github.com/chiefcll)

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -86,7 +86,15 @@ class Circuitbox
     end
 
     def circuit_open_value(env, service_response, exception)
-      env[:circuit_breaker_default_value] || default_value.call(service_response, exception)
+      env[:circuit_breaker_default_value] || call_default_lambda(service_response, exception)
+    end
+
+    def call_default_lambda(service_response, exception)
+      if default_value.arity == 2
+        default_value.call(service_response, exception)
+      else
+        default_value.call(service_response)
+      end
     end
 
     def circuit(env)

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -27,11 +27,23 @@ class Circuitbox
       env = { url: "url" }
       give(circuitbox).circuit("url", anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
-      default_value_generator = lambda { |_| :sential }
+      default_value_generator = lambda { |*| :sential }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
                                          default_value: default_value_generator)
       assert_equal :sential, middleware.call(env)
+    end
+
+    def test_default_value_generator_lambda_passed_error
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuit).run!(anything) { raise Circuitbox::Error.new("error text") }
+      default_value_generator = lambda { |_,error| error.message }
+      middleware = FaradayMiddleware.new(app,
+                                         circuitbox: circuitbox,
+                                         default_value: default_value_generator)
+      assert_equal "error text", middleware.call(env)
     end
 
     def test_overwrite_default_value_generator_static_value

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -27,7 +27,7 @@ class Circuitbox
       env = { url: "url" }
       give(circuitbox).circuit("url", anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
-      default_value_generator = lambda { |*| :sential }
+      default_value_generator = lambda { |response| :sential }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
                                          default_value: default_value_generator)

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -1,5 +1,6 @@
 require "integration_helper"
 require "typhoeus/adapters/faraday"
+require 'pry'
 
 class Circuitbox
 
@@ -42,7 +43,8 @@ class Circuitbox
       open_circuit
       open_circuit_response = connection.get(failure_url)
       assert_equal open_circuit_response.status, 503
-      assert open_circuit_response.original_response.nil?
+      assert_nil open_circuit_response.original_response
+      assert_kind_of Circuitbox::OpenCircuitError, open_circuit_response.original_exception
     end
 
     def test_closed_circuit_response

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -1,6 +1,5 @@
 require "integration_helper"
 require "typhoeus/adapters/faraday"
-require 'pry'
 
 class Circuitbox
 


### PR DESCRIPTION
If the Faraday middleware fails before getting a response from Faraday (e.g. because the circuit is open) then the lambda passed for the `default_value` option gets no information about what went wrong.  Fix this by providing both the Faraday response and the error.  

This changes the signature required by the `default_value` lambda, so requires at least a 'minor' version bump to indicate a breaking change.