### PR TITLE
Circuitbox::ServiceFailureError should include exceptions message or name of exception if no message is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.
 
 ### version next
 
+### v0.10.3
+- Circuitbox::ServiceFailureError wraps the original exception that was raised.
+  The behaviour for to_s wasn't exposing this information and was returning the
+  name of class "Circuitbox::ServiceFailureError". Change the behaviour for to_s
+  to indicate this exception is a wrapper around the original exception.
+  [sherrry](https://github.com/sherrry)
+
 ### v0.10.2
 - Faraday middleware passes two arguments to the `default_value` callback, not
   just one.  First argument is still the error response from Faraday if there is

--- a/lib/circuitbox/errors/service_failure_error.rb
+++ b/lib/circuitbox/errors/service_failure_error.rb
@@ -7,5 +7,9 @@ class Circuitbox
       @original = exception
     end
 
+    def to_s
+      "#{self.class.name} wrapped: #{original}"
+    end
+
   end
 end

--- a/test/service_failure_error_test.rb
+++ b/test/service_failure_error_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ServiceFailureErrorTest < Minitest::Test
+  class SomeOtherError < StandardError; end;
+  
+  describe 'to_s' do
+    it 'includes message for wrapped exception' do
+      some_error = SomeOtherError.new("some other error")
+      ex = Circuitbox::ServiceFailureError.new('test', some_error)
+      assert_equal "Circuitbox::ServiceFailureError wrapped: #{some_error}", ex.to_s
+    end
+  end
+end


### PR DESCRIPTION
Circuitbox::ServiceFailureError wraps the original exception that was raised. The behaviour for to_s wasn't exposing this information and was returning the name of class "Circuitbox::ServiceFailureError". Change the behaviour for to_s to indicate this exception is a wrapper around the original exception. 