### PR TITLE
Notifier: Extract ActiveSupport::Notifications to own class (solves #24)

### DIFF
--- a/lib/circuitbox/active_support_notifier.rb
+++ b/lib/circuitbox/active_support_notifier.rb
@@ -1,0 +1,27 @@
+require 'circuitbox/notifier'
+require 'active_support/notifications'
+
+class Circuitbox
+  class ActiveSupportNotifier < Notifier
+    def notify(event)
+      ActiveSupport::Notifications.instrument("circuit_#{event}", {
+        circuit: circuit_name
+      })
+    end
+
+    def notify_warning(message)
+      ActiveSupport::Notifications.instrument('circuit_warning', {
+        circuit: circuit_name,
+        message: message
+      })
+    end
+
+    def metric_gauge(gauge, value)
+      ActiveSupport::Notifications.instrument('circuit_gauge', {
+        circuit: circuit_name,
+        gauge: gauge.to_s,
+        value: value
+      })
+    end
+  end
+end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -25,7 +25,7 @@ class Circuitbox
       @service = service
       @circuit_options = options
       @circuit_store   = options.fetch(:cache) { Circuitbox.circuit_store }
-      @notifier        = options.fetch(:notifier_class) { Notifier }
+      @notifier        = options.fetch(:notifier_class) { NullNotifier }
 
       @exceptions = options.fetch(:exceptions) { [] }
       @exceptions = [Timeout::Error] if @exceptions.blank?

--- a/lib/circuitbox/notifier.rb
+++ b/lib/circuitbox/notifier.rb
@@ -1,34 +1,22 @@
 class Circuitbox
   class Notifier
-    def initialize(service, partition=nil)
+    def initialize(service, partition = nil)
       @service   = service
       @partition = partition
     end
 
-    def notify(event)
-      return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: circuit_name)
-    end
-
-    def notify_warning(message)
-      return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_warning", { circuit: circuit_name, message: message})
-    end
-
-    def metric_gauge(gauge, value)
-      return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_gauge", { circuit: circuit_name, gauge: gauge.to_s, value: value })
-    end
-
     private
-    def circuit_name
-      circuit_name = @service.to_s
-      circuit_name += ":#{@partition}" if @partition
-      circuit_name
-    end
 
-    def notification_available?
-      defined? ActiveSupport::Notifications
+    def circuit_name
+      [@service, @partition].compact.map(&:to_s).join(':')
     end
+  end
+
+  class NullNotifier < Notifier
+    def notify(event); end
+
+    def notify_warning(message); end
+
+    def metric_gauge(gauge, value); end
   end
 end

--- a/test/active_support_notifier_test.rb
+++ b/test/active_support_notifier_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'circuitbox/active_support_notifier'
+
+describe Circuitbox::ActiveSupportNotifier do
+  subject { Circuitbox::ActiveSupportNotifier.new(:yammer, 12) }
+
+  it '[notify] sends an ActiveSupport::Notification' do
+    ActiveSupport::Notifications.expects(:instrument)
+      .with('circuit_open', circuit: 'yammer:12')
+
+    subject.notify(:open)
+  end
+
+  it '[notify_warning] sends an ActiveSupport::Notification' do
+    ActiveSupport::Notifications.expects(:instrument)
+      .with('circuit_warning', circuit: 'yammer:12', message: 'hello')
+
+    subject.notify_warning('hello')
+  end
+
+  it '[gauge] sends an ActiveSupport::Notifier' do
+    ActiveSupport::Notifications.expects(:instrument)
+      .with('circuit_gauge', circuit: 'yammer:12', gauge: 'ratio', value: 12)
+
+    subject.metric_gauge(:ratio, 12)
+  end
+end

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -1,21 +1,29 @@
 require 'test_helper'
 require 'circuitbox/notifier'
-require 'active_support/notifications'
 
 describe Circuitbox::Notifier do
-  it "[notify] sends an ActiveSupport::Notification" do
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_open", circuit: 'yammer:12')
-    Circuitbox::Notifier.new(:yammer, 12).notify(:open)
+  describe '#initialize' do
+    subject { Circuitbox::Notifier }
+
+    it 'need at least the service parameter' do
+      proc { subject.new }.must_raise ArgumentError
+      subject.new(:a_service).must_be_instance_of(Circuitbox::Notifier)
+    end
+  end
+end
+
+describe Circuitbox::NullNotifier do
+  subject { Circuitbox::NullNotifier.new(:yammer, 12) }
+
+  it 'respond to .notify' do
+    assert subject.respond_to?(:notify)
   end
 
-  it "[notify_warning] sends an ActiveSupport::Notification" do
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_warning", { circuit: 'yammer:12', message: 'hello'})
-    Circuitbox::Notifier.new(:yammer, 12).notify_warning('hello')
+  it 'respond to .notify_warning' do
+    assert subject.respond_to?(:notify_warning)
   end
 
-  it '[gauge] sends an ActiveSupport::Notifier' do
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_gauge", { circuit: 'yammer:12', gauge: 'ratio', value: 12})
-    Circuitbox::Notifier.new(:yammer, 12).metric_gauge(:ratio, 12)
-
+  it 'respond to .metric_gauge' do
+    assert subject.respond_to?(:metric_gauge)
   end
 end


### PR DESCRIPTION
this is updated version after great suggestions https://github.com/yammer/circuitbox/issues/24#issuecomment-112839576
I'm still trying figure out how should look proper test for Notifier initialization
https://github.com/yammer/circuitbox/blob/76be38afff3fd0cb25481c89d49f8ac12e91c9f1/lib/circuitbox/notifier.rb#L3-L6 
Or maybe it should be moved completely to `NullNotifier` ?
My thinking is that it should stay at `Notifier` class as inherit in `ActiveSupportNotifier` from `NullNotifier`  doesn't feel right and I want keep their "contract" same. 

Also I'm not sure if `circuit_name`
https://github.com/yammer/circuitbox/compare/master...keram:activesupport_notifier_extraction#diff-9c7f72bcf0155adb73713ce47725e233R29
should  be moved into parent class. 

What are your thoughts?
