### PR TITLE
Keep the original backtrace around

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,0 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-guard :minitest do
-  # with Minitest::Unit
-  watch(%r{^test/(.*)_test\.rb$})
-  watch(%r{^lib/circuitbox/([^/]+)\.rb$})     { |m| "test/#{m[1]}_test.rb" }
-  watch(%r{^test/test_helper\.rb$})      { 'test' }
-end

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack"
-  spec.add_development_dependency "guard-minitest"
-  spec.add_development_dependency "guard"
   spec.add_development_dependency "gimme"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/lib/circuitbox/errors/service_failure_error.rb
+++ b/lib/circuitbox/errors/service_failure_error.rb
@@ -5,11 +5,12 @@ class Circuitbox
     def initialize(service, exception)
       @service = service
       @original = exception
+      # we copy over the original exceptions backtrace if there is one
+      set_backtrace(exception.backtrace) unless exception.backtrace.empty?
     end
 
     def to_s
       "#{self.class.name} wrapped: #{original}"
     end
-
   end
 end

--- a/test/service_failure_error_test.rb
+++ b/test/service_failure_error_test.rb
@@ -1,13 +1,30 @@
 require 'test_helper'
 
-class ServiceFailureErrorTest < Minitest::Test
+describe Circuitbox::ServiceFailureError do
   class SomeOtherError < StandardError; end;
-  
-  describe 'to_s' do
-    it 'includes message for wrapped exception' do
-      some_error = SomeOtherError.new("some other error")
-      ex = Circuitbox::ServiceFailureError.new('test', some_error)
-      assert_equal "Circuitbox::ServiceFailureError wrapped: #{some_error}", ex.to_s
+
+  attr_reader :error
+
+  before do
+    begin
+      raise SomeOtherError, "some other error"
+    rescue => ex
+      @error = ex
     end
   end
+
+  describe '#to_s' do
+    it 'includes message for wrapped exception' do
+      ex = Circuitbox::ServiceFailureError.new('test', error)
+      assert_equal "Circuitbox::ServiceFailureError wrapped: #{error}", ex.to_s
+    end
+  end
+
+  describe '#backtrace' do
+    it 'keeps the original exception backtrace' do
+      ex = Circuitbox::ServiceFailureError.new('test', error)
+      assert_equal error.backtrace, ex.backtrace
+    end
+  end
+
 end


### PR DESCRIPTION
When we raise a ServiceFailureError we don't want to mask the original
exception, so even when we keep it around as a property we need to keep
the backtrace as well, the easiest way todo this is to copy the
backtrace when we create the exception.