### PR TITLE
Excon middleware

### DIFF
--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "typhoeus"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "faraday"
+  spec.add_development_dependency "excon"
   spec.add_development_dependency "logger"
   spec.add_development_dependency "bundler-gem_version_tasks"
 

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -1,0 +1,99 @@
+require 'excon'
+require 'circuitbox'
+
+class Circuitbox
+  class ExconMiddleware < Excon::Middleware::Base
+    class RequestFailed < StandardError; end
+
+    DEFAULT_EXCEPTIONS = [
+      Excon::Errors::Timeout,
+      RequestFailed
+    ]
+
+    class NullResponse < Excon::Response
+      def initialize
+        super(status: 503, response_headers: {})
+      end
+    end
+
+    attr_reader :opts
+
+    def initialize(stack, opts = {})
+      @stack = stack
+      default_options = { open_circuit: lambda { |response| !(200..299).include?(response.status) } }
+      @opts = default_options.merge(opts)
+      super(stack)
+    end
+
+    def error_call(datum)
+      circuit_open_value(datum)
+    end
+
+    def request_call(datum)
+      circuit(datum).run!(run_options(datum)) do
+        @stack.request_call(datum)
+      end
+    end
+
+    def response_call(datum)
+      @stack.response_call(datum)
+      service_response = Excon::Response.new(datum)
+      raise RequestFailed if open_circuit?(service_response)
+      service_response
+    end
+
+    def identifier
+      @identifier ||= opts.fetch(:identifier, ->(env) { env[:url] })
+    end
+
+    def exceptions
+      circuit_breaker_options[:exceptions]
+    end
+
+    private
+
+    def circuit(env)
+      id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
+      circuitbox.circuit id, circuit_breaker_options
+    end
+
+    def run_options(env)
+      env[:circuit_breaker_run_options] || {}
+    end
+
+    def open_circuit?(response)
+      opts[:open_circuit].call(response)
+    end
+
+    def circuitbox
+      @circuitbox ||= opts.fetch(:circuitbox, Circuitbox)
+    end
+
+    def circuit_open_value(env)
+      env[:circuit_breaker_default_value] || default_value.call
+    end
+
+    def circuit_breaker_options
+      return @circuit_breaker_options if @current_adapter
+
+      @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
+      @circuit_breaker_options.merge!(
+        exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
+      )
+    end
+
+    def default_value
+      return @default_value if @default_value
+
+      default = opts.fetch(:default_value) do
+        lambda { NullResponse.new }
+      end
+
+      @default_value = if default.respond_to?(:call)
+                         default
+                       else
+                         lambda { |*| default }
+                       end
+    end
+  end
+end

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -16,6 +16,10 @@ class Circuitbox
         @original_exception = exception
         super(status: 503, response_headers: {})
       end
+
+      def []=(key, value)
+        @data[key] = value
+      end
     end
 
     attr_reader :opts

--- a/test/excon_middleware_test.rb
+++ b/test/excon_middleware_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+require 'circuitbox/excon_middleware'
+
+class SentialException < StandardError; end
+
+class Circuitbox
+  class ExconMiddlewareTest < Minitest::Test
+
+    attr_reader :app
+
+    def setup
+      @app = gimme
+    end
+
+    def test_default_identifier
+      env = { url: "sential" }
+      assert_equal "sential", ExconMiddleware.new(app).identifier.call(env)
+    end
+
+    def test_overwrite_identifier
+      middleware = ExconMiddleware.new(app, identifier: "sential")
+      assert_equal middleware.identifier, "sential"
+    end
+
+    def test_overwrite_default_value_generator_lambda
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuit).run!(anything) { raise Circuitbox::Error }
+      default_value_generator = lambda { :sential }
+      middleware = ExconMiddleware.new(app,
+                                         circuitbox: circuitbox,
+                                         default_value: default_value_generator)
+      assert_equal :sential, middleware.error_call(env)
+    end
+
+    def test_overwrite_default_value_generator_static_value
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuit).run!(anything) { raise Circuitbox::Error }
+      middleware = ExconMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
+      assert_equal :sential, middleware.error_call(env)
+    end
+
+    def test_default_exceptions
+      middleware = ExconMiddleware.new(app)
+      assert_includes middleware.exceptions, Excon::Errors::Timeout
+      assert_includes middleware.exceptions, ExconMiddleware::RequestFailed
+    end
+
+    def test_overridde_success_response
+      env = { url: "url", status: 400 }
+      error_response = lambda { |r| r.status >= 500 }
+      mw = ExconMiddleware.new(app, open_circuit: error_response)
+      response = mw.response_call(env)
+      assert_kind_of Excon::Response, response
+      assert_equal response.status, 400
+    end
+
+    def test_default_success_response
+      env = { url: "url", status: 400 }
+      app = gimme
+      give(app).request_call(anything) { Excon::Response.new(status: 400) }
+      response = nil
+
+      begin
+        mw = ExconMiddleware.new(app)
+        mw.response_call(env)
+      rescue
+        response = mw.error_call(env)
+      end
+
+      assert_kind_of Excon::Response, response
+      assert_equal response.status, 503
+    end
+
+    def test_overwrite_exceptions
+      middleware = ExconMiddleware.new(app, exceptions: [SentialException])
+      assert_includes middleware.exceptions, SentialException
+    end
+
+    def test_pass_circuit_breaker_run_options
+      stub_circuitbox
+      give(circuit).run!(:sential)
+      give(circuitbox).circuit("url", anything) { circuit }
+      env = { url: "url", circuit_breaker_run_options: :sential }
+      middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
+      middleware.request_call(env)
+      verify(circuit, 1.times).run!(:sential)
+    end
+
+    def test_pass_circuit_breaker_options
+      stub_circuitbox
+      env = { url: "url" }
+      expected_circuit_breaker_options = {
+        sential: :sential,
+        exceptions: ExconMiddleware::DEFAULT_EXCEPTIONS
+      }
+      give(circuitbox).circuit("url", expected_circuit_breaker_options) { circuit }
+      options = { circuitbox: circuitbox, circuit_breaker_options: { sential: :sential } }
+      middleware = ExconMiddleware.new(app, options)
+      middleware.request_call(env)
+
+      verify(circuitbox, 1.times).circuit("url", expected_circuit_breaker_options)
+    end
+
+    def test_overwrite_circuitbreaker_default_value
+      stub_circuitbox
+      env = { url: "url", circuit_breaker_default_value: :sential }
+      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuit).run!(anything) { raise Circuitbox::Error }
+      middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
+      assert_equal middleware.error_call(env), :sential
+    end
+
+    def test_return_null_response_for_open_circuit
+      stub_circuitbox
+      env = { url: "url" }
+      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuitbox).circuit("url", anything) { circuit }
+      mw = ExconMiddleware.new(app, circuitbox: circuitbox)
+      response = mw.error_call(env)
+      assert_kind_of Excon::Response, response
+      assert_equal response.status, 503
+    end
+
+    attr_reader :circuitbox, :circuit
+    def stub_circuitbox
+      @circuitbox = gimme
+      @circuit = gimme
+    end
+  end
+end


### PR DESCRIPTION
This adds an excon middleware implementation to circuitbox. The interesting part is that excon departs from other middleware in that it doesn't contain a single `call` method, but instead breaks it up into `request_call` and two handlers `response_call` and `error_call`. This method works, the downside being that it needs to call the cache twice.