### PR TITLE
Only open circuit on "real" errors

### DIFF
--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -21,10 +21,18 @@ class Circuitbox
 
     attr_reader :opts
 
+    DEFAULT_CIRCUITBOX_OPTIONS = {
+      open_circuit: lambda do |response|
+        # response.status:
+        # nil -> connection could not be established, or failed very hard
+        # 5xx -> non recoverable server error, oposed to 4xx which are client errors
+        response.status.nil? || (500 <= response.status && response.status <= 599)
+      end
+    }
+
     def initialize(app, opts = {})
       @app = app
-      default_options = { open_circuit: lambda { |response| !response.success? } }
-      @opts = default_options.merge(opts)
+      @opts = DEFAULT_CIRCUITBOX_OPTIONS.merge(opts)
       super(app)
     end
 
@@ -101,5 +109,6 @@ class Circuitbox
       id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
       circuitbox.circuit id, circuit_breaker_options
     end
+
   end
 end


### PR DESCRIPTION
A circuitbox circuit should only open on a server error not on a client
error. This in general means everything above 500, and 0 (connection
failure).
This is the new default, as opening on 4xx especially 401 Unauthorized
causes, problems.

fixes #45