### PR TITLE
bugfix/ Invalid Moneta cache expiration handling

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -112,7 +112,7 @@ class Circuitbox
     def open!
       log_event :open
       logger.debug "[CIRCUIT] opening #{service} circuit"
-      circuit_store.store(storage_key(:asleep), true, expires_in: option_value(:sleep_window).seconds)
+      circuit_store.store(storage_key(:asleep), true, expires: option_value(:sleep_window))
       half_open!
       was_open!
     end


### PR DESCRIPTION
According to this documentation, Moneta requires `expires` as key for expirations
https://github.com/minad/moneta#expiration

This is also reported as issue here #51 