### PR TITLE
Respect sleep time

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,11 @@ use with Unicorn. It depends on the `daybreak` gem.
 
 ```ruby
 require "daybreak"
-Circuitbox.circuit :identifier, cache: Moneta.new(:Daybreak, file: "db.daybreak")
+Circuitbox.circuit :identifier, cache: Moneta.new(:Daybreak, file: "db.daybreak", expires: true)
 ```
+
+It is important for the store to have
+[expires](https://github.com/minad/moneta#backend-feature-matrix) support.
 
 ## Faraday
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ c.use Circuitbox::FaradayMiddleware, open_circuit: lambda { |response| response.
 
 ## CHANGELOG
 ### version next
+- fix timeout issue for default configuration, as default `:Memory` adapter does
+  not natively support expires, we need to actually load it on demand.
+- fix memoization of `circuit_breaker_options` not actually doing memoization in
+  `excon` and `faraday` middleware.
 
 ### v1.0.2
 - Fix timeout issue [#51](https://github.com/yammer/circuitbox/issues/51)

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -36,7 +36,7 @@ class Circuitbox
   end
 
   def self.circuit_store
-    self.instance.circuit_store ||= Moneta.new(:Memory)
+    self.instance.circuit_store ||= Moneta.new(:Memory, expires: true)
   end
 
   def self.circuit_store=(store)

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -86,7 +86,7 @@ class Circuitbox
     end
 
     def circuit_breaker_options
-      return @circuit_breaker_options if @current_adapter
+      return @circuit_breaker_options if @circuit_breaker_options
 
       @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
       @circuit_breaker_options.merge!(

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -63,7 +63,7 @@ class Circuitbox
     end
 
     def circuit_breaker_options
-      return @circuit_breaker_options if @current_adapter
+      return @circuit_breaker_options if @circuit_breaker_options
 
       @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
       @circuit_breaker_options.merge!(


### PR DESCRIPTION
The default implementation of the moneta memory store does not implement
a native expire, this means that the `asleep` flag is not actually
respected by default. Passing `expire: true` on initialization requires
`Moneta::Expire` which implements expire in ruby for any implementation.

Also added some docs to make sure users know about the requirement for a
store to either implement native expire, or provide expire in software
via `Moneta::Expire`. Even though a native implementation is probably
preferred a non native works fine.