### PR TITLE
Test Cleanup Part II

### DIFF
--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -2,20 +2,20 @@ require 'test_helper'
 require 'circuitbox/notifier'
 require 'active_support/notifications'
 
-describe Circuitbox::Notifier do
-  it "[notify] sends an ActiveSupport::Notification" do
+
+class NotifierTest < Minitest::Test
+  def test_sends_notification_on_notify
     ActiveSupport::Notifications.expects(:instrument).with("circuit_open", circuit: 'yammer:12')
     Circuitbox::Notifier.new(:yammer, 12).notify(:open)
   end
 
-  it "[notify_warning] sends an ActiveSupport::Notification" do
+  def test_sends_warning_notificaiton_notify_warning
     ActiveSupport::Notifications.expects(:instrument).with("circuit_warning", { circuit: 'yammer:12', message: 'hello'})
     Circuitbox::Notifier.new(:yammer, 12).notify_warning('hello')
   end
 
-  it '[gauge] sends an ActiveSupport::Notifier' do
+  def test_sends_metric_as_notification
     ActiveSupport::Notifications.expects(:instrument).with("circuit_gauge", { circuit: 'yammer:12', gauge: 'ratio', value: 12})
     Circuitbox::Notifier.new(:yammer, 12).metric_gauge(:ratio, 12)
-
   end
 end

--- a/test/service_failure_error_test.rb
+++ b/test/service_failure_error_test.rb
@@ -1,30 +1,23 @@
 require 'test_helper'
 
-describe Circuitbox::ServiceFailureError do
+class ServiceFailureErrorTest < Minitest::Test
   class SomeOtherError < StandardError; end;
 
   attr_reader :error
 
-  before do
-    begin
-      raise SomeOtherError, "some other error"
-    rescue => ex
-      @error = ex
-    end
+  def setup
+    raise SomeOtherError, "some other error"
+  rescue => ex
+    @error = ex
   end
 
-  describe '#to_s' do
-    it 'includes message for wrapped exception' do
-      ex = Circuitbox::ServiceFailureError.new('test', error)
-      assert_equal "Circuitbox::ServiceFailureError wrapped: #{error}", ex.to_s
-    end
+  def test_includes_the_message_of_the_wrapped_exception
+    ex = Circuitbox::ServiceFailureError.new('test', error)
+    assert_equal "Circuitbox::ServiceFailureError wrapped: #{error}", ex.to_s
   end
 
-  describe '#backtrace' do
-    it 'keeps the original exception backtrace' do
-      ex = Circuitbox::ServiceFailureError.new('test', error)
-      assert_equal error.backtrace, ex.backtrace
-    end
+  def test_keeps_the_original_backtrace
+    ex = Circuitbox::ServiceFailureError.new('test', error)
+    assert_equal error.backtrace, ex.backtrace
   end
-
 end


### PR DESCRIPTION
Since the majority of the tests have been written in `assert` and
`Minitest` style, this adjusts the remaining files to be in the same
style.