### PR TITLE
Add event when the block is going to be skipped due to a circuit being open

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -47,6 +47,7 @@ class Circuitbox
       if open?
         logger.debug "[CIRCUIT] open: skipping #{service}"
         open! unless open_flag?
+        skipped!
         raise Circuitbox::OpenCircuitError.new(service)
       else
         close! if was_open?
@@ -168,6 +169,10 @@ class Circuitbox
 
     def failure!
       log_event :failure
+    end
+
+    def skipped!
+      log_event :skipped
     end
 
     # Store success/failure/open/close data in memcache

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -231,6 +231,14 @@ class CircuitBreakerTest < Minitest::Test
     emulate_circuit_run(circuit, :failure, Timeout::Error)
   end
 
+  def test_records_response_skipped
+    circuit = Circuitbox::CircuitBreaker.new(:yammer)
+    circuit.stubs(:open? => true)
+    circuit.stubs(:log_event)
+    circuit.expects(:log_event).with(:skipped)
+    emulate_circuit_run(circuit, :failure, Timeout::Error)
+  end
+
   def test_records_response_success
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     circuit.expects(:log_event).with(:success)


### PR DESCRIPTION
Currently, we only emit events when the circuit is first opened/closed or when the request succeeds/fails.  This leaves a gap when a request is attempted, but the block doesn't even attempt to run because the circuit is already open.

This PR allows clients to quantify the effect of an open circuit by measuring how many runs are being skipped.

I'm not 100% sold on calling this `skipped`, but its the best name I've got at the moment.  We could also quantify this as a `failure` event.

Thoughts on adding this?
