### PR TITLE
Remove timeout option as using ruby's timeout is dangerous in various ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class ExampleServiceClient
 
       # seconds the circuit stays open once it has passed the error threshold
       sleep_window:     300,
-      
+
       # length of interval (in seconds) over which it calculates the error rate
       time_window:      60,
 
@@ -66,9 +66,6 @@ class ExampleServiceClient
 
       # exceeding this rate will open the circuit
       error_threshold:  50,
-
-      # seconds before the circuit times out
-      timeout_seconds:  1
 
       # Logger to use
       logger: Logger.new(STDOUT)

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'logger'
-require 'timeout'
 require 'moneta'
 require 'active_support/all'
 

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -26,7 +26,6 @@ class CircuitBreakerTest < Minitest::Test
                                                 sleep_window: 300,
                                                 volume_threshold: 5,
                                                 error_threshold: 33,
-                                                timeout_seconds: 1,
                                                 exceptions: [Timeout::Error])
     end
 
@@ -148,7 +147,6 @@ class CircuitBreakerTest < Minitest::Test
                                                 time_window: 2,
                                                 volume_threshold: 5,
                                                 error_threshold: 5,
-                                                timeout_seconds: 1,
                                                 exceptions: [Timeout::Error])
     end
 


### PR DESCRIPTION
While having a generic timeout in circuit box is helpful the use of ruby's timeout is very dangerous and should be handled on a case by case basis.

For networking related code, timeouts would be better handled at a lower level where everything can be cleaned up properly.

Timeout may still be useful for some things (I can not come up with any good ones though). If someone really needs to use Timeout the exception can be specified using the ```exceptions:``` option. It would now be up to the user of the circuit to handle timeouts on their own.

@yarmand @bmorton 