### PR TITLE
Only create one notifier per circuit. Optimize string use in notifier.

### DIFF
--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -13,7 +13,7 @@ require 'circuitbox/errors/open_circuit_error'
 require 'circuitbox/errors/service_failure_error'
 
 class Circuitbox
-  attr_accessor :circuits, :circuit_store
+  attr_accessor :circuits, :circuit_store, :notifier
   cattr_accessor :configure
 
   def self.instance
@@ -39,6 +39,14 @@ class Circuitbox
 
   def self.circuit_store=(store)
     self.instance.circuit_store = store
+  end
+
+  def self.default_notifier
+    self.instance.notifier ||= Notifier.new
+  end
+
+  def self.default_notifier=(notifier)
+    self.instance.notifier = notifier
   end
 
   def self.[](service_identifier, options = {})

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -26,8 +26,9 @@ class Circuitbox
       @service = service
       @circuit_options = options
       @circuit_store   = options.fetch(:cache) { Circuitbox.circuit_store }
-      @notifier        = options.fetch(:notifier_class) { Notifier }
       @execution_timer = options.fetch(:execution_timer) { SimpleTimer }
+      notifier_class = options.fetch(:notifier_class) { Notifier }
+      @notifier = notifier_class.new(service)
 
       @exceptions = options.fetch(:exceptions) { [] }
       @exceptions = [Timeout::Error] if @exceptions.blank?
@@ -177,22 +178,21 @@ class Circuitbox
 
     # Store success/failure/open/close data in memcache
     def log_event(event)
-      notifier.new(service).notify(event)
+      notifier.notify(event)
       log_event_to_process(event)
     end
 
     def log_metrics(error_rate, failures, successes)
-      n = notifier.new(service)
-      n.metric_gauge(:error_rate, error_rate)
-      n.metric_gauge(:failure_count, failures)
-      n.metric_gauge(:success_count, successes)
+      notifier.metric_gauge(:error_rate, error_rate)
+      notifier.metric_gauge(:failure_count, failures)
+      notifier.metric_gauge(:success_count, successes)
     end
 
     def sanitize_options
       sleep_window = option_value(:sleep_window)
       time_window  = option_value(:time_window)
       if sleep_window < time_window
-        notifier.new(service).notify_warning("sleep_window:#{sleep_window} is shorter than time_window:#{time_window}, the error_rate could not be reset properly after a sleep. sleep_window as been set to equal time_window.")
+        notifier.notify_warning("sleep_window:#{sleep_window} is shorter than time_window:#{time_window}, the error_rate could not be reset properly after a sleep. sleep_window as been set to equal time_window.")
         @circuit_options[:sleep_window] = option_value(:time_window)
       end
     end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -23,12 +23,11 @@ class Circuitbox
     # `logger`            - Logger to use - defaults to Rails.logger if defined, otherwise STDOUT
     #
     def initialize(service, options = {})
-      @service = service
+      @service = service.to_s
       @circuit_options = options
       @circuit_store   = options.fetch(:cache) { Circuitbox.circuit_store }
       @execution_timer = options.fetch(:execution_timer) { SimpleTimer }
-      notifier_class = options.fetch(:notifier_class) { Notifier }
-      @notifier = notifier_class.new(service)
+      @notifier = options.fetch(:notifier) { Circuitbox.default_notifier }
 
       @exceptions = options.fetch(:exceptions) { [] }
       @exceptions = [Timeout::Error] if @exceptions.blank?
@@ -54,7 +53,7 @@ class Circuitbox
         logger.debug "[CIRCUIT] closed: querying #{service}"
 
         begin
-          response = execution_timer.time(notifier.new(service), :execution_time) do
+          response = execution_timer.time(service, notifier, :execution_time) do
             if exceptions.include? Timeout::Error
               timeout_seconds = run_options.fetch(:timeout_seconds) { option_value(:timeout_seconds) }
               timeout (timeout_seconds) { yield }
@@ -178,21 +177,21 @@ class Circuitbox
 
     # Store success/failure/open/close data in memcache
     def log_event(event)
-      notifier.notify(event)
+      notifier.notify(service, event)
       log_event_to_process(event)
     end
 
     def log_metrics(error_rate, failures, successes)
-      notifier.metric_gauge(:error_rate, error_rate)
-      notifier.metric_gauge(:failure_count, failures)
-      notifier.metric_gauge(:success_count, successes)
+      notifier.metric_gauge(service, :error_rate, error_rate)
+      notifier.metric_gauge(service, :failure_count, failures)
+      notifier.metric_gauge(service, :success_count, successes)
     end
 
     def sanitize_options
       sleep_window = option_value(:sleep_window)
       time_window  = option_value(:time_window)
       if sleep_window < time_window
-        notifier.notify_warning("sleep_window:#{sleep_window} is shorter than time_window:#{time_window}, the error_rate could not be reset properly after a sleep. sleep_window as been set to equal time_window.")
+        notifier.notify_warning(service, "sleep_window:#{sleep_window} is shorter than time_window:#{time_window}, the error_rate could not be reset properly after a sleep. sleep_window as been set to equal time_window.")
         @circuit_options[:sleep_window] = option_value(:time_window)
       end
     end

--- a/lib/circuitbox/notifier.rb
+++ b/lib/circuitbox/notifier.rb
@@ -2,23 +2,19 @@
 
 class Circuitbox
   class Notifier
-    def initialize(service)
-      @circuit_name = service.to_s
+    def notify(circuit_name, event)
+      return unless notification_available?
+      ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: circuit_name)
     end
 
-    def notify(event)
+    def notify_warning(circuit_name, message)
       return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: @circuit_name)
+      ActiveSupport::Notifications.instrument('circuit_warning', circuit: circuit_name, message: message)
     end
 
-    def notify_warning(message)
+    def metric_gauge(circuit_name, gauge, value)
       return unless notification_available?
-      ActiveSupport::Notifications.instrument('circuit_warning', circuit: @circuit_name, message: message)
-    end
-
-    def metric_gauge(gauge, value)
-      return unless notification_available?
-      ActiveSupport::Notifications.instrument('circuit_gauge', circuit: @circuit_name, gauge: gauge.to_s, value: value)
+      ActiveSupport::Notifications.instrument('circuit_gauge', circuit: circuit_name, gauge: gauge.to_s, value: value)
     end
 
   private

--- a/lib/circuitbox/notifier.rb
+++ b/lib/circuitbox/notifier.rb
@@ -1,28 +1,27 @@
+# frozen_string_literal: true
+
 class Circuitbox
   class Notifier
     def initialize(service)
-      @service = service
+      @circuit_name = service.to_s
     end
 
     def notify(event)
       return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: circuit_name)
+      ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: @circuit_name)
     end
 
     def notify_warning(message)
       return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_warning", { circuit: circuit_name, message: message})
+      ActiveSupport::Notifications.instrument('circuit_warning', circuit: @circuit_name, message: message)
     end
 
     def metric_gauge(gauge, value)
       return unless notification_available?
-      ActiveSupport::Notifications.instrument("circuit_gauge", { circuit: circuit_name, gauge: gauge.to_s, value: value })
+      ActiveSupport::Notifications.instrument('circuit_gauge', circuit: @circuit_name, gauge: gauge.to_s, value: value)
     end
 
-    private
-    def circuit_name
-      @service.to_s
-    end
+  private
 
     def notification_available?
       defined? ActiveSupport::Notifications

--- a/lib/circuitbox/timer/monotonic_timer.rb
+++ b/lib/circuitbox/timer/monotonic_timer.rb
@@ -1,9 +1,9 @@
 class MonotonicTimer
-  def self.time(notifier, metric_name, time_unit = :milliseconds)
+  def self.time(service, notifier, metric_name, time_unit = :milliseconds)
     before = Process.clock_gettime(Process::CLOCK_MONOTONIC, time_unit)
     result = yield
     after = Process.clock_gettime(Process::CLOCK_MONOTONIC, time_unit)
-    notifier.metric_gauge(metric_name, before - after)
+    notifier.metric_gauge(service, metric_name, before - after)
     result
   end
 end

--- a/lib/circuitbox/timer/null_timer.rb
+++ b/lib/circuitbox/timer/null_timer.rb
@@ -1,5 +1,5 @@
 class NullTimer
-  def self.time(notifier, metric_name)
+  def self.time(service, notifier, metric_name)
     yield
   end
 end

--- a/lib/circuitbox/timer/simple_timer.rb
+++ b/lib/circuitbox/timer/simple_timer.rb
@@ -1,9 +1,9 @@
 class SimpleTimer
-  def self.time(notifier, metric_name)
+  def self.time(service, notifier, metric_name)
     before = Time.now.to_f
     result = yield
     after = Time.now.to_f
-    notifier.metric_gauge(metric_name, before - after)
+    notifier.metric_gauge(service, metric_name, before - after)
     result
   end
 end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -12,6 +12,12 @@ class CircuitboxTest < Minitest::Test
     assert_equal store, Circuitbox[:yammer].circuit_store
   end
 
+  def test_default_notifier_is_configurable
+    notifier = gimme
+    Circuitbox.default_notifier = notifier
+    assert_equal notifier, Circuitbox.default_notifier
+  end
+
   def test_delegates_to_circuit
     Circuitbox.expects(:circuit).with(:yammer, {})
     Circuitbox[:yammer]
@@ -32,7 +38,7 @@ class CircuitboxTest < Minitest::Test
     assert_equal 1337, circuit_one.option_value(:sleep_window)
     assert_equal 1337, circuit_two.option_value(:sleep_window)
   end
-  
+
   def test_uses_parsed_uri_host_as_identifier_for_circuit
     service = Circuitbox.parameter_to_service_name("http://api.yammer.com/api/v1/messages")
     assert_equal "api.yammer.com", service

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -6,16 +6,16 @@ require 'active_support/notifications'
 class NotifierTest < Minitest::Test
   def test_sends_notification_on_notify
     ActiveSupport::Notifications.expects(:instrument).with("circuit_open", circuit: 'yammer')
-    Circuitbox::Notifier.new(:yammer).notify(:open)
+    Circuitbox::Notifier.new.notify('yammer', :open)
   end
 
   def test_sends_warning_notificaiton_notify_warning
     ActiveSupport::Notifications.expects(:instrument).with("circuit_warning", { circuit: 'yammer', message: 'hello'})
-    Circuitbox::Notifier.new(:yammer).notify_warning('hello')
+    Circuitbox::Notifier.new.notify_warning('yammer', 'hello')
   end
 
   def test_sends_metric_as_notification
     ActiveSupport::Notifications.expects(:instrument).with("circuit_gauge", { circuit: 'yammer', gauge: 'ratio', value: 12})
-    Circuitbox::Notifier.new(:yammer).metric_gauge(:ratio, 12)
+    Circuitbox::Notifier.new.metric_gauge('yammer', :ratio, 12)
   end
 end


### PR DESCRIPTION
We've been creating a new notifier object every time log_event is called. We should be able to create one when the circuit is initialized and re-use the object for subsequent calls to log_event. Same thing goes for metric_gauge.

We can take advantage of frozen string literal in notifier also.

I realize notifications can be re-factored to not rely on active support notifications (so it doesn't require rails), but that's for another PR.