### PR TITLE
Allow timeout_seconds to be set to nil to not use ruby timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ class ExampleServiceClient
       error_threshold:  50,
 
       # seconds before the circuit times out
+      # if set to nil no timeout is used
       timeout_seconds:  1
 
       # Logger to use

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -198,6 +198,12 @@ class CircuitBreakerTest < Minitest::Test
     emulate_circuit_run(circuit, :success, StandardError)
   end
 
+  def test_should_not_use_timeout_class_if_timeout_window_nil
+    circuit = Circuitbox::CircuitBreaker.new(:yammer, timeout_seconds: nil)
+    circuit.expects(:timeout).never
+    emulate_circuit_run(circuit, :success, 'success')
+  end
+
   def test_should_return_response_if_it_doesnt_timeout
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     response = emulate_circuit_run(circuit, :success, "success")


### PR DESCRIPTION
Fixes #69 by adding the option of setting timeout_seconds to nil to not handle timeouts in circuit box.