### PR TITLE
Add default_timer to circuitbox

### DIFF
--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -7,13 +7,13 @@ require 'active_support/all'
 require 'circuitbox/version'
 require 'circuitbox/circuit_breaker'
 require 'circuitbox/notifier'
-require 'circuitbox/timer/simple_timer'
+require 'circuitbox/timer/simple'
 require 'circuitbox/errors/error'
 require 'circuitbox/errors/open_circuit_error'
 require 'circuitbox/errors/service_failure_error'
 
 class Circuitbox
-  attr_accessor :circuits, :circuit_store, :notifier
+  attr_accessor :circuits, :circuit_store, :notifier, :timer
   cattr_accessor :configure
 
   def self.instance
@@ -47,6 +47,14 @@ class Circuitbox
 
   def self.default_notifier=(notifier)
     self.instance.notifier = notifier
+  end
+
+  def self.default_timer
+    self.instance.timer ||= Timer::Simple.new
+  end
+
+  def self.default_timer=(timer)
+    self.instance.timer = timer
   end
 
   def self.[](service_identifier, options = {})

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -26,7 +26,7 @@ class Circuitbox
       @service = service.to_s
       @circuit_options = options
       @circuit_store   = options.fetch(:cache) { Circuitbox.circuit_store }
-      @execution_timer = options.fetch(:execution_timer) { SimpleTimer }
+      @execution_timer = options.fetch(:execution_timer) { Circuitbox.default_timer }
       @notifier = options.fetch(:notifier) { Circuitbox.default_notifier }
 
       @exceptions = options.fetch(:exceptions) { [] }

--- a/lib/circuitbox/timer/monotonic.rb
+++ b/lib/circuitbox/timer/monotonic.rb
@@ -9,7 +9,7 @@ class Circuitbox
         before = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
         result = yield
         after = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
-        notifier.metric_gauge(service, metric_name, before - after)
+        notifier.metric_gauge(service, metric_name, after - before)
         result
       end
     end

--- a/lib/circuitbox/timer/monotonic.rb
+++ b/lib/circuitbox/timer/monotonic.rb
@@ -1,0 +1,17 @@
+class Circuitbox
+  class Timer
+    class Monotonic
+      def initialize(time_unit = :milliseconds)
+        @time_unit = time_unit
+      end
+
+      def time(service, notifier, metric_name)
+        before = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
+        result = yield
+        after = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
+        notifier.metric_gauge(service, metric_name, before - after)
+        result
+      end
+    end
+  end
+end

--- a/lib/circuitbox/timer/monotonic_timer.rb
+++ b/lib/circuitbox/timer/monotonic_timer.rb
@@ -1,9 +1,0 @@
-class MonotonicTimer
-  def self.time(service, notifier, metric_name, time_unit = :milliseconds)
-    before = Process.clock_gettime(Process::CLOCK_MONOTONIC, time_unit)
-    result = yield
-    after = Process.clock_gettime(Process::CLOCK_MONOTONIC, time_unit)
-    notifier.metric_gauge(service, metric_name, before - after)
-    result
-  end
-end

--- a/lib/circuitbox/timer/null.rb
+++ b/lib/circuitbox/timer/null.rb
@@ -1,0 +1,9 @@
+class Circuitbox
+  class Timer
+    class Null
+      def time(_service, _notifier, _metric_name)
+        yield
+      end
+    end
+  end
+end

--- a/lib/circuitbox/timer/null_timer.rb
+++ b/lib/circuitbox/timer/null_timer.rb
@@ -1,5 +1,0 @@
-class NullTimer
-  def self.time(service, notifier, metric_name)
-    yield
-  end
-end

--- a/lib/circuitbox/timer/simple.rb
+++ b/lib/circuitbox/timer/simple.rb
@@ -1,0 +1,13 @@
+class Circuitbox
+  class Timer
+    class Simple
+      def time(service, notifier, metric_name)
+        before = Time.now.to_f
+        result = yield
+        after = Time.now.to_f
+        notifier.metric_gauge(service, metric_name, before - after)
+        result
+      end
+    end
+  end
+end

--- a/lib/circuitbox/timer/simple.rb
+++ b/lib/circuitbox/timer/simple.rb
@@ -5,7 +5,7 @@ class Circuitbox
         before = Time.now.to_f
         result = yield
         after = Time.now.to_f
-        notifier.metric_gauge(service, metric_name, before - after)
+        notifier.metric_gauge(service, metric_name, after - before)
         result
       end
     end

--- a/lib/circuitbox/timer/simple_timer.rb
+++ b/lib/circuitbox/timer/simple_timer.rb
@@ -1,9 +1,0 @@
-class SimpleTimer
-  def self.time(service, notifier, metric_name)
-    before = Time.now.to_f
-    result = yield
-    after = Time.now.to_f
-    notifier.metric_gauge(service, metric_name, before - after)
-    result
-  end
-end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'circuitbox/timer/null_timer'
+require 'circuitbox/timer/null'
 
 class CircuitBreakerTest < Minitest::Test
   class ConnectionError < StandardError; end;
@@ -406,7 +406,8 @@ class CircuitBreakerTest < Minitest::Test
 
     def test_not_notify_circuit_execution_time_on_null_timer
       notifier = gimme_notifier(metric: :execution_time, metric_value: Gimme::Matchers::Anything.new)
-      circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier, execution_timer: NullTimer)
+      timer = Circuitbox::Timer::Null.new
+      circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier, execution_timer: timer)
       circuit.run { 'success' }
       refute notifier.metric_sent?, 'execution time metric sent'
     end


### PR DESCRIPTION
This change add's a default_timer to Circuitbox. It also moves the timers under the Circuitbox namespace as to not conflict with user's classes.