### PR TITLE
Fix should_open? to always report error rate metrics

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -112,8 +112,16 @@ class Circuitbox
     end
 
   private
+
     def should_open?
-      passed_volume_threshold? && passed_rate_threshold?
+      failures = failure_count
+      successes = success_count
+      rate = error_rate(failures, successes)
+
+      log_metrics(rate, failures, successes)
+
+      failures + successes > option_value(:volume_threshold) &&
+        rate >= option_value(:error_threshold)
     end
 
     def open!
@@ -149,22 +157,6 @@ class Circuitbox
 
     def half_open?
       circuit_store.key?(storage_key(:half_open))
-    end
-
-    def passed_volume_threshold?
-      success_count + failure_count > option_value(:volume_threshold)
-    end
-
-    def passed_rate_threshold?
-      read_and_log_error_rate >= option_value(:error_threshold)
-    end
-
-    def read_and_log_error_rate
-      failures = failure_count
-      success  = success_count
-      rate = error_rate(failures, success)
-      log_metrics(rate, failures, success)
-      rate
     end
 
     def success!

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -120,8 +120,15 @@ class Circuitbox
 
       log_metrics(rate, failures, successes)
 
-      failures + successes > option_value(:volume_threshold) &&
-        rate >= option_value(:error_threshold)
+      passed_volume_threshold?(failures, successes) && passed_rate_threshold?(rate)
+    end
+
+    def passed_volume_threshold?(failures, successes)
+      failures + successes > option_value(:volume_threshold)
+    end
+
+    def passed_rate_threshold?(rate)
+      rate >= option_value(:error_threshold)
     end
 
     def open!

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -308,6 +308,23 @@ class CircuitBreakerTest < Minitest::Test
     assert circuit.open?
   end
 
+  def test_open_checks_if_volume_threshold_has_passed
+    circuit = Circuitbox::CircuitBreaker.new(:yammer)
+    circuit.stubs(open_flag?: false)
+
+    circuit.expects(:passed_volume_threshold?).with(0, 0).once
+    circuit.open?
+  end
+
+  def test_open_checks_error_rate_threshold
+    circuit = Circuitbox::CircuitBreaker.new(:yammer)
+    circuit.stubs(open_flag?: false,
+                  passed_volume_threshold?: true)
+
+   circuit.expects(:passed_rate_threshold?).with(0.0).once
+   circuit.open?
+  end
+
   def test_open_is_false_if_awake_and_under_rate_threshold
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     circuit.stubs(:open_flag? => false,

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -308,23 +308,6 @@ class CircuitBreakerTest < Minitest::Test
     assert circuit.open?
   end
 
-  def test_open_checks_if_volume_threshold_has_passed
-    circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open_flag? => false)
-
-    circuit.expects(:passed_volume_threshold?).once
-    circuit.open?
-  end
-
-  def test_open_checks_error_rate_threshold
-    circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open_flag? => false,
-                  :passed_volume_threshold? => true)
-
-    circuit.expects(:passed_rate_threshold?).once
-    circuit.open?
-  end
-
   def test_open_is_false_if_awake_and_under_rate_threshold
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     circuit.stubs(:open_flag? => false,
@@ -332,15 +315,6 @@ class CircuitBreakerTest < Minitest::Test
                   :passed_rate_threshold => false)
 
     assert !circuit.open?
-  end
-
-  def test_error_rate_threshold_calculation
-    circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:failure_count => 3, :success_count => 2)
-    assert circuit.send(:passed_rate_threshold?)
-
-    circuit.stubs(:failure_count => 2, :success_count => 3)
-    assert !circuit.send(:passed_rate_threshold?)
   end
 
   def test_logs_and_retrieves_success_events


### PR DESCRIPTION
If the volume threshold was not met error rate metrics would not be sent. This changes ```should_open?``` to always log the error_rate. This should mean theres a minor perf hit for circuit calls before the volume threshold has passed, but after performance should be better for various reasons explained below.

I originally came across this while doing some profiling on ```should_open?```. Multiple snapshots of failure_count and success_count were taken, one in ```passed_volume_threshold?``` and another in ```read_and_log_error_rate```. It's somewhat expensive to get these values because cache keys need to be generated and then values looked up from the cache.

It's possible to make my changes slightly faster by inlining ```error_rate``` and storing ```failures + successes``` into a local variable.