### PR TITLE
Improve the way moneta is used

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -206,11 +206,6 @@ class Circuitbox
       end
     end
 
-    # When there is a successful response within a count interval, clear the failures.
-    def clear_failures!
-      circuit_store.store(stat_storage_key(:failure), 0, raw: true)
-    end
-
     def stat_storage_key(event)
       "#{storage_key('stats'.freeze)}:#{align_time_to_window}:#{event}"
     end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -135,7 +135,7 @@ class Circuitbox
     end
 
     def was_open?
-      circuit_store[storage_key(:was_open)].present?
+      circuit_store.key?(storage_key(:was_open))
     end
     ### END
 
@@ -144,11 +144,11 @@ class Circuitbox
     end
 
     def open_flag?
-      circuit_store[storage_key(:asleep)].present?
+      circuit_store.key?(storage_key(:asleep))
     end
 
     def half_open?
-      circuit_store[storage_key(:half_open)].present?
+      circuit_store.key?(storage_key(:half_open))
     end
 
     def passed_volume_threshold?

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -123,7 +123,7 @@ class CircuitBreakerTest < Minitest::Test
         store(expiring_key, initial_value)
       end
 
-      def load(key, options = {})
+      def key?(key, options = {})
         if key == @expiring_key
           @expiring_key = nil # only override the first call
           value = super


### PR DESCRIPTION
This removes the use of active support ```present?``` for checking values and simply checks if the keys exist.

The skipped, open, close, methods were incrementing a stat key that was never used, so I've added a new method to just notify the notifier.

At the same time success and failure need to notify the notifier and increment a stat key so what used to be ```log_event``` is now ```notify_and_increment_event```. When I was browsing through the moneta documentation increment was being called without first setting a key to "1". I simplified ```log_event_to_process```, which was just incrementing, into a single line which is now in ```notify_and_increment_event```.

The ```clear_failures!``` method was private and was not used so it has been cleaned up.