### PR TITLE
Retrieve host from faraday / excon not from circuitbox

### DIFF
--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -16,23 +16,16 @@ class Circuitbox
   class << self
     include Configuration
 
-    def [](service_identifier, options = {})
-      circuit(service_identifier, options)
+    def [](service_name, options = {})
+      circuit(service_name, options)
     end
 
-    def circuit(service_identifier, options = {})
-      service_name = parameter_to_service_name(service_identifier)
-
+    def circuit(service_name, options = {})
       circuit = (cached_circuits[service_name] ||= CircuitBreaker.new(service_name, options))
 
       return circuit unless block_given?
 
       circuit.run { yield }
-    end
-
-    def parameter_to_service_name(param)
-      uri = URI(param.to_s)
-      uri.host.present? ? uri.host : param.to_s
     end
   end
 end

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -55,7 +55,7 @@ class Circuitbox
     end
 
     def identifier
-      @identifier ||= opts.fetch(:identifier, ->(env) { env[:path] })
+      @identifier ||= opts.fetch(:identifier, ->(env) { env[:host] })
     end
 
     def exceptions

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -53,7 +53,10 @@ class Circuitbox
     end
 
     def identifier
-      @identifier ||= opts.fetch(:identifier, ->(env) { env[:url] })
+      # It's possible for the URL object to not have a host at the time the middleware
+      # is run. To not break circuitbox by creating a circuit with a nil service name
+      # we can get the string representation of the URL object and use that as the service name.
+      @identifier ||= opts.fetch(:identifier, ->(env) { env[:url].host || env[:url].to_s })
     end
 
     private
@@ -109,6 +112,5 @@ class Circuitbox
       id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
       circuitbox.circuit id, circuit_breaker_options
     end
-
   end
 end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -49,14 +49,4 @@ class CircuitboxTest < Minitest::Test
     assert_equal 1337, circuit_one.option_value(:sleep_window)
     assert_equal 1337, circuit_two.option_value(:sleep_window)
   end
-
-  def test_uses_parsed_uri_host_as_identifier_for_circuit
-    service = Circuitbox.parameter_to_service_name("http://api.yammer.com/api/v1/messages")
-    assert_equal "api.yammer.com", service
-  end
-
-  def test_uses_identifier_directly_for_circuit_if_it_is_not_an_uri
-    service = Circuitbox.parameter_to_service_name(:yammer)
-    assert_equal "yammer", service
-  end
 end

--- a/test/excon_middleware_test.rb
+++ b/test/excon_middleware_test.rb
@@ -13,8 +13,8 @@ class Circuitbox
     end
 
     def test_default_identifier
-      env = { path: "sential" }
-      assert_equal "sential", ExconMiddleware.new(app).identifier.call(env)
+      env = { host: 'yammer.com' }
+      assert_equal 'yammer.com', ExconMiddleware.new(app).identifier.call(env)
     end
 
     def test_overwrite_identifier
@@ -24,8 +24,8 @@ class Circuitbox
 
     def test_overwrite_default_value_generator_lambda
       stub_circuitbox
-      env = { path: "path" }
-      give(circuitbox).circuit("path", anything) { circuit }
+      env = { host: 'yammer.com' }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       default_value_generator = lambda { |_, _| :sential }
       middleware = ExconMiddleware.new(app,
@@ -36,8 +36,8 @@ class Circuitbox
 
     def test_overwrite_default_value_generator_static_value
       stub_circuitbox
-      env = { path: "path" }
-      give(circuitbox).circuit("path", anything) { circuit }
+      env = { host: 'yammer.com' }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
       assert_equal :sential, middleware.error_call(env)
@@ -50,7 +50,7 @@ class Circuitbox
     end
 
     def test_overridde_success_response
-      env = { path: "path", response: { status: 400 } }
+      env = { host: 'yammer.com', response: { status: 400 } }
       error_response = lambda { |r| r[:status] >= 500 }
       give(app).response_call(anything) { Excon::Response.new(status: 400) }
       mw = ExconMiddleware.new(app, open_circuit: error_response)
@@ -60,7 +60,7 @@ class Circuitbox
     end
 
     def test_default_success_response
-      env = { path: "path", response: { status: 400 } }
+      env = { host: 'yammer.com', response: { status: 400 } }
       app = gimme
       give(app).response_call(anything) { Excon::Response.new(status: 400) }
       response = nil
@@ -80,8 +80,8 @@ class Circuitbox
     def test_pass_circuit_breaker_run_options
       stub_circuitbox
       give(circuit).run!(:sential)
-      give(circuitbox).circuit("path", anything) { circuit }
-      env = { path: "path", circuit_breaker_run_options: :sential }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
+      env = { host: 'yammer.com', circuit_breaker_run_options: :sential }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
       middleware.request_call(env)
       verify(circuit, 1.times).run!(:sential)
@@ -89,23 +89,23 @@ class Circuitbox
 
     def test_pass_circuit_breaker_options
       stub_circuitbox
-      env = { path: "path" }
+      env = { host: 'yammer.com' }
       expected_circuit_breaker_options = {
         sential: :sential,
         exceptions: ExconMiddleware::DEFAULT_EXCEPTIONS
       }
-      give(circuitbox).circuit("path", expected_circuit_breaker_options) { circuit }
+      give(circuitbox).circuit('yammer.com', expected_circuit_breaker_options) { circuit }
       options = { circuitbox: circuitbox, circuit_breaker_options: { sential: :sential } }
       middleware = ExconMiddleware.new(app, options)
       middleware.request_call(env)
 
-      verify(circuitbox, 1.times).circuit("path", expected_circuit_breaker_options)
+      verify(circuitbox, 1.times).circuit('yammer.com', expected_circuit_breaker_options)
     end
 
     def test_overwrite_circuitbreaker_default_value
       stub_circuitbox
-      env = { path: "path", circuit_breaker_default_value: :sential }
-      give(circuitbox).circuit("path", anything) { circuit }
+      env = { host: 'yammer.com', circuit_breaker_default_value: :sential }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.error_call(env), :sential
@@ -113,9 +113,9 @@ class Circuitbox
 
     def test_return_null_response_for_open_circuit
       stub_circuitbox
-      env = { path: "path" }
+      env = { host: 'yammer.com' }
       give(circuit).run!(anything) { raise Circuitbox::Error }
-      give(circuitbox).circuit("path", anything) { circuit }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       mw = ExconMiddleware.new(app, circuitbox: circuitbox)
       response = mw.error_call(env)
       assert_kind_of Excon::Response, response

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -13,8 +13,8 @@ class Circuitbox
     end
 
     def test_default_identifier
-      env = { url: "sential" }
-      assert_equal "sential", FaradayMiddleware.new(app).identifier.call(env)
+      env = { url: URI('http://yammer.com/') }
+      assert_equal 'yammer.com', FaradayMiddleware.new(app).identifier.call(env)
     end
 
     def test_overwrite_identifier
@@ -24,8 +24,8 @@ class Circuitbox
 
     def test_overwrite_default_value_generator_lambda
       stub_circuitbox
-      env = { url: "url" }
-      give(circuitbox).circuit("url", anything) { circuit }
+      env = { url: URI('http://yammer.com/') }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       default_value_generator = lambda { |response| :sential }
       middleware = FaradayMiddleware.new(app,
@@ -36,8 +36,8 @@ class Circuitbox
 
     def test_default_value_generator_lambda_passed_error
       stub_circuitbox
-      env = { url: "url" }
-      give(circuitbox).circuit("url", anything) { circuit }
+      env = { url: URI('http://yammer.com/') }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error.new("error text") }
       default_value_generator = lambda { |_,error| error.message }
       middleware = FaradayMiddleware.new(app,
@@ -48,8 +48,8 @@ class Circuitbox
 
     def test_overwrite_default_value_generator_static_value
       stub_circuitbox
-      env = { url: "url" }
-      give(circuitbox).circuit("url", anything) { circuit }
+      env = { url: URI('http://yammer.com/') }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
       assert_equal :sential, middleware.call(env)
@@ -62,7 +62,7 @@ class Circuitbox
     end
 
     def test_overridde_success_response
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       app = gimme
       give(app).call(anything) { Faraday::Response.new(status: 500) }
       error_response = lambda { |response|  false }
@@ -74,7 +74,7 @@ class Circuitbox
     end
 
     def test_default_success_response
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       app = gimme
       give(app).call(anything) { Faraday::Response.new(status: 500) }
       response = FaradayMiddleware.new(app).call(env)
@@ -85,7 +85,7 @@ class Circuitbox
     end
 
     def test_default_open_circuit_does_not_trip_on_400
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       app = gimme
       give(app).call(anything) { Faraday::Response.new(status: 400) }
       response = FaradayMiddleware.new(app).call(env)
@@ -96,7 +96,7 @@ class Circuitbox
     end
 
     def test_default_open_circuit_does_trip_on_nil
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       app = gimme
       give(app).call(anything) { Faraday::Response.new(status: nil) }
       response = FaradayMiddleware.new(app).call(env)
@@ -114,8 +114,8 @@ class Circuitbox
     def test_pass_circuit_breaker_run_options
       stub_circuitbox
       give(circuit).run!(:sential)
-      give(circuitbox).circuit("url", anything) { circuit }
-      env = { url: "url", circuit_breaker_run_options: :sential }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
+      env = { url: URI('http://yammer.com/'), circuit_breaker_run_options: :sential }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
       middleware.call(env)
       verify(circuit, 1.times).run!(:sential)
@@ -123,23 +123,23 @@ class Circuitbox
 
     def test_pass_circuit_breaker_options
       stub_circuitbox
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       expected_circuit_breaker_options = {
         sential: :sential,
         exceptions: FaradayMiddleware::DEFAULT_EXCEPTIONS
       }
-      give(circuitbox).circuit("url", expected_circuit_breaker_options) { circuit }
+      give(circuitbox).circuit('yammer.com', expected_circuit_breaker_options) { circuit }
       options = { circuitbox: circuitbox, circuit_breaker_options: { sential: :sential } }
       middleware = FaradayMiddleware.new(app, options)
       middleware.call(env)
 
-      verify(circuitbox, 1.times).circuit("url", expected_circuit_breaker_options)
+      verify(circuitbox, 1.times).circuit('yammer.com', expected_circuit_breaker_options)
     end
 
     def test_overwrite_circuitbreaker_default_value
       stub_circuitbox
-      env = { url: "url", circuit_breaker_default_value: :sential }
-      give(circuitbox).circuit("url", anything) { circuit }
+      env = { url: URI('http://yammer.com/'), circuit_breaker_default_value: :sential }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run!(anything) { raise Circuitbox::Error }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.call(env), :sential
@@ -147,18 +147,18 @@ class Circuitbox
 
     def test_return_value_closed_circuit
       stub_circuitbox
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       give(circuit).run!(anything) { :sential }
-      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.call(env), :sential
     end
 
     def test_return_null_response_for_open_circuit
       stub_circuitbox
-      env = { url: "url" }
+      env = { url: URI('http://yammer.com/') }
       give(circuit).run!(anything) { raise Circuitbox::Error }
-      give(circuitbox).circuit("url", anything) { circuit }
+      give(circuitbox).circuit('yammer.com', anything) { circuit }
       response = FaradayMiddleware.new(app, circuitbox: circuitbox).call(env)
       assert_kind_of Faraday::Response, response
       assert_equal response.status, 503


### PR DESCRIPTION
This changes the excon middleware from using path as the default identifier to host. I don't think path worked as expected, since it would be creating circuits for things like '/api' and not the actual host. Excon exposes the host in the environment it gives the middleware, this change makes use of that to not require any further parsing.

Faraday is a little different then excon and has yet to validate the url contains a host at the time the middleware is called. It defaults to using the host, if that is nil then it uses the string representation of the url. I came across this when testing making a request through faraday with '/test' in which case the url object was 'http:///test' which when parsing the host returns nil. This is just so we don't create a circuit with a nil service name, might make things slightly easier for debugging if this is encountered.

With this change the ```parameter_to_service_name``` makes less sense for circuitbox to handle. It's not really documented besides two test cases and adds quite a bit of overhead to accessing circuits through ```Circuitbox.circuit```.