### PR TITLE
Update the syntax and reduce random test failures

### DIFF
--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -231,8 +231,8 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_should_return_response_if_it_doesnt_timeout
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    response = emulate_circuit_run(circuit, :success, "success")
-    assert_equal "success", response
+    response = emulate_circuit_run(circuit, :success, 'success')
+    assert_equal 'success', response
   end
 
   def test_timeout_seconds_run_options_overrides_circuit_options
@@ -242,14 +242,14 @@ class CircuitBreakerTest < Minitest::Test
   end
 
   def test_catches_connection_error_failures_if_defined
-    circuit = Circuitbox::CircuitBreaker.new(:yammer, :exceptions => [ConnectionError])
+    circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [ConnectionError])
     response = emulate_circuit_run(circuit, :failure, ConnectionError)
-    assert_equal nil, response
+    assert_nil response
   end
 
   def test_doesnt_catch_out_of_scope_exceptions
     sentinal = Class.new(StandardError)
-    circuit = Circuitbox::CircuitBreaker.new(:yammer, :exceptions => [ConnectionError, Timeout::Error])
+    circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [ConnectionError, Timeout::Error])
 
     assert_raises(sentinal) do
       emulate_circuit_run(circuit, :failure, sentinal)
@@ -257,14 +257,14 @@ class CircuitBreakerTest < Minitest::Test
   end
 
   def test_records_response_failure
-    circuit = Circuitbox::CircuitBreaker.new(:yammer, :exceptions => [Timeout::Error])
+    circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
     circuit.expects(:notify_and_increment_event).with(:failure)
     emulate_circuit_run(circuit, :failure, Timeout::Error)
   end
 
   def test_records_response_skipped
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:should_open? => true)
+    circuit.stubs(should_open?: true)
     circuit.stubs(:notify_event)
     circuit.expects(:notify_event).with(:skipped)
     emulate_circuit_run(circuit, :failure, Timeout::Error)
@@ -273,26 +273,26 @@ class CircuitBreakerTest < Minitest::Test
   def test_records_response_success
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     circuit.expects(:notify_and_increment_event).with(:success)
-    emulate_circuit_run(circuit, :success, "success")
+    emulate_circuit_run(circuit, :success, 'success')
   end
 
   def test_does_not_send_request_if_circuit_is_open
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open? => true)
+    circuit.stubs(open?: true)
     circuit.expects(:yield).never
     response = emulate_circuit_run(circuit, :failure, Timeout::Error)
-    assert_equal nil, response
+    assert_nil response
   end
 
   def test_returns_nil_response_on_failed_request
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     response = emulate_circuit_run(circuit, :failure, Timeout::Error)
-    assert_equal nil, response
+    assert_nil response
   end
 
   def test_puts_circuit_to_sleep_once_opened
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:should_open? => true)
+    circuit.stubs(should_open?: true)
 
     assert !circuit.send(:open_flag?)
     emulate_circuit_run(circuit, :failure, Timeout::Error)
@@ -304,7 +304,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_open_is_true_if_open_flag
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open_flag? => true)
+    circuit.stubs(open_flag?: true)
     assert circuit.open?
   end
 
@@ -327,9 +327,9 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_open_is_false_if_awake_and_under_rate_threshold
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
-    circuit.stubs(:open_flag? => false,
-                  :passed_volume_threshold? => false,
-                  :passed_rate_threshold => false)
+    circuit.stubs(open_flag?: false,
+                  passed_volume_threshold?: false,
+                  passed_rate_threshold: false)
 
     assert !circuit.open?
   end
@@ -381,16 +381,16 @@ class CircuitBreakerTest < Minitest::Test
     def test_notification_on_open
       notifier = gimme_notifier
       circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier)
-      10.times { circuit.run { raise Timeout::Error }}
+      10.times { circuit.run { raise Timeout::Error } }
       assert notifier.notified?, 'no notification sent'
     end
 
     def test_notification_on_close
       notifier = gimme_notifier
       circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier)
-      5.times { circuit.run { raise Timeout::Error }}
+      5.times { circuit.run { raise Timeout::Error } }
       notifier.clear_notified!
-      10.times { circuit.run { 'success' }}
+      10.times { circuit.run { 'success' } }
       assert notifier.notified?, 'no notification sent'
     end
 
@@ -415,21 +415,21 @@ class CircuitBreakerTest < Minitest::Test
     def test_notifies_on_success_rate_calculation
       notifier = gimme_notifier(metric: :error_rate, metric_value: 0.0)
       circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier)
-      10.times { circuit.run { "success" } }
-      assert notifier.notified?, "no notification sent"
+      10.times { circuit.run { 'success' } }
+      assert notifier.notified?, 'no notification sent'
     end
 
     def test_notifies_on_error_rate_calculation
       notifier = gimme_notifier(metric: :failure_count, metric_value: 1)
       circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier)
-      10.times { circuit.run { raise Timeout::Error  }}
+      10.times { circuit.run { raise Timeout::Error } }
       assert notifier.notified?, 'no notification sent'
     end
 
     def test_success_count_on_error_rate_calculation
       notifier = gimme_notifier(metric: :success_count, metric_value: 6)
       circuit = Circuitbox::CircuitBreaker.new(:yammer, notifier: notifier)
-      10.times { circuit.run { 'success' }}
+      10.times { circuit.run { 'success' } }
       assert notifier.notified?, 'no notification sent'
     end
 
@@ -463,11 +463,10 @@ class CircuitBreakerTest < Minitest::Test
       refute notifier.metric_sent?, 'execution time metric sent'
     end
 
-    def gimme_notifier(opts={})
+    def gimme_notifier(opts = {})
       service = opts.fetch(:service, 'yammer').to_s
       metric = opts.fetch(:metric, :error_rate)
       metric_value = opts.fetch(:metric_value, 0.0)
-      warning_msg = opts.fetch(:warning_msg, '')
       fake_notifier = gimme
       notified = false
       metric_sent = false

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'circuitbox/timer/null'
 

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -1,20 +1,26 @@
 require 'test_helper'
 
 class CircuitboxTest < Minitest::Test
-
   def setup
     Circuitbox.send(:clear_cached_circuits!)
   end
 
+  def teardown
+    Circuitbox.default_notifier = nil
+    Circuitbox.default_logger = nil
+    Circuitbox.default_circuit_store = nil
+    Circuitbox.default_timer = nil
+  end
+
   def test_configure_block_clears_cached_circuits
     Circuitbox.expects(:clear_cached_circuits!)
-    Circuitbox.configure { }
+    Circuitbox.configure {}
   end
 
   def test_default_circuit_store_is_configurable
-    store = Moneta.new(:Memory, expires: true)
+    store = gimme
     Circuitbox.default_circuit_store = store
-    assert_equal store, Circuitbox[:yammer].circuit_store
+    assert_equal store, Circuitbox.default_circuit_store
   end
 
   def test_default_notifier_is_configurable
@@ -24,9 +30,15 @@ class CircuitboxTest < Minitest::Test
   end
 
   def test_default_logger_is_configurable
-    logger = Logger.new(STDOUT)
+    logger = gimme
     Circuitbox.default_logger = logger
     assert_equal logger, Circuitbox.default_logger
+  end
+
+  def test_default_timer_is_configurable
+    timer = gimme
+    Circuitbox.default_timer = timer
+    assert_equal timer, Circuitbox.default_timer
   end
 
   def test_delegates_to_circuit
@@ -43,8 +55,8 @@ class CircuitboxTest < Minitest::Test
   end
 
   def test_sets_the_circuit_options_the_first_time_only
-    circuit_one = Circuitbox.circuit(:yammer, :sleep_window => 1337)
-    circuit_two = Circuitbox.circuit(:yammer, :sleep_window => 2000)
+    circuit_one = Circuitbox.circuit(:yammer, sleep_window: 1337)
+    circuit_two = Circuitbox.circuit(:yammer, sleep_window: 2000)
 
     assert_equal 1337, circuit_one.option_value(:sleep_window)
     assert_equal 1337, circuit_two.option_value(:sleep_window)

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CircuitboxTest < Minitest::Test

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -11,7 +11,7 @@ class Circuitbox
 
     def setup
       @app = gimme
-      #Circuitbox.configure { |config| config.default_circuit_store = Moneta.new(:Memory, expires: true) }
+      Circuitbox.configure { |config| config.default_circuit_store = Moneta.new(:Memory, expires: true) }
     end
 
     def test_default_identifier

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'circuitbox/faraday_middleware'
 
@@ -5,11 +7,11 @@ class SentialException < StandardError; end
 
 class Circuitbox
   class FaradayMiddlewareTest < Minitest::Test
-
     attr_reader :app
 
     def setup
       @app = gimme
+      #Circuitbox.configure { |config| config.default_circuit_store = Moneta.new(:Memory, expires: true) }
     end
 
     def test_default_identifier
@@ -18,8 +20,8 @@ class Circuitbox
     end
 
     def test_overwrite_identifier
-      middleware = FaradayMiddleware.new(app, identifier: "sential")
-      assert_equal middleware.identifier, "sential"
+      middleware = FaradayMiddleware.new(app, identifier: 'sential')
+      assert_equal middleware.identifier, 'sential'
     end
 
     def test_overwrite_default_value_generator_lambda
@@ -38,12 +40,12 @@ class Circuitbox
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error.new("error text") }
-      default_value_generator = lambda { |_,error| error.message }
+      give(circuit).run!(anything) { raise Circuitbox::Error, 'error text' }
+      default_value_generator = ->(_, error) { error.message }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
                                          default_value: default_value_generator)
-      assert_equal "error text", middleware.call(env)
+      assert_equal 'error text', middleware.call(env)
     end
 
     def test_overwrite_default_value_generator_static_value
@@ -65,7 +67,7 @@ class Circuitbox
       env = { url: URI('http://yammer.com/') }
       app = gimme
       give(app).call(anything) { Faraday::Response.new(status: 500) }
-      error_response = lambda { |response|  false }
+      error_response = ->(_) { false }
       response = FaradayMiddleware.new(app, open_circuit: error_response).call(env)
       assert_kind_of Faraday::Response, response
       assert_equal response.status, 500


### PR DESCRIPTION
This contains a few updates to the test suite. There is still more work that needs to be done here but this is a good start. The big changes are removing the use of sleep in one of the tests and making the time cop usage predictable between invocations of the test suite.