### PR TITLE
clean up redundant code in circuit_breaker.rb

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -72,15 +72,13 @@ class Circuitbox
         end
       end
 
-      return response
+      response
     end
 
     def run(run_options = {})
-      begin
-        run!(run_options, &Proc.new)
-      rescue Circuitbox::Error
-        nil
-      end
+      run!(run_options, &Proc.new)
+    rescue Circuitbox::Error
+      nil
     end
 
     def open?


### PR DESCRIPTION
There is a redundant return call and a begin that can be removed.