### PR TITLE
Remove support for ruby 1.9.3 - 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 matrix:
   allow_failures:

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -3,8 +3,6 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'circuitbox/version'
 
-ruby_2_2_2_plus = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.2")
-
 Gem::Specification.new do |spec|
   spec.name          = "circuitbox"
   spec.version       = Circuitbox::VERSION
@@ -22,11 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  if ruby_2_2_2_plus
-    spec.add_development_dependency "rack"
-  else
-    spec.add_development_dependency "rack", '< 2'
-  end
+  spec.add_development_dependency "rack"
   spec.add_development_dependency "gimme"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
@@ -39,10 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "lmdb"
   spec.add_development_dependency "daybreak"
 
-  if ruby_2_2_2_plus
-    spec.add_dependency "activesupport"
-  else
-    spec.add_dependency "activesupport", '< 5'
-  end
+  spec.add_dependency "activesupport"
   spec.add_dependency "moneta"
 end


### PR DESCRIPTION
By supporting old rubies, like 1.9.3, it is hard to support newer language features like keyword args. Also some of the memory reduction changes in the master branch don't actually do anything on version 2.2 and below.