### PR TITLE
make the default moneta in memory store threadsafe

### DIFF
--- a/lib/circuitbox/configuration.rb
+++ b/lib/circuitbox/configuration.rb
@@ -16,7 +16,7 @@ class Circuitbox
     end
 
     def default_circuit_store
-      @default_circuit_store ||= Moneta.new(:Memory, expires: true)
+      @default_circuit_store ||= Moneta.new(:Memory, expires: true, threadsafe: true)
     end
 
     def default_notifier


### PR DESCRIPTION
this fixes #93. The moneta memory store is not thread safe by default. By passing the thread safe option moneta wraps most/all calls to it with a mutex. This should make the default store work better when using threaded web servers.