### PR TITLE
update mocha's minitest integration

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'timecop'
 require 'gimme'
 require 'circuitbox'


### PR DESCRIPTION
When using the latest version of mocha it complains that requiring 'mocha/mini_test' is deprecated and  'mocha/minitest' should be used.