### PR TITLE
Allow bypassing Timeout::timeout when tracking a Timeout::Error

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -14,13 +14,14 @@ class Circuitbox
     #
     # Configuration options
     #
-    # `sleep_window`      - seconds to sleep the circuit
-    # `volume_threshold`  - number of requests before error rate calculation occurs
-    # `error_threshold`   - percentage of failed requests needed to trip circuit
-    # `timeout_seconds`   - seconds until it will timeout the request
-    # `exceptions`        - exceptions other than Timeout::Error that count as failures
-    # `time_window`       - interval of time used to calculate error_rate (in seconds) - default is 60s
-    # `logger`            - Logger to use - defaults to Rails.logger if defined, otherwise STDOUT
+    # `sleep_window`       - seconds to sleep the circuit
+    # `volume_threshold`   - number of requests before error rate calculation occurs
+    # `error_threshold`    - percentage of failed requests needed to trip circuit
+    # `timeout_seconds`    - seconds until it will timeout the request
+    # `exceptions`         - exceptions other than Timeout::Error that count as failures
+    # `time_window`        - interval of time used to calculate error_rate (in seconds) - default is 60s
+    # `logger`             - Logger to use - defaults to Rails.logger if defined, otherwise STDOUT
+    # `use_unsafe_timeout` - Use ruby timeout if exceptions also contain Timeout::Error - default true
     #
     def initialize(service, options = {})
       @service = service.to_s
@@ -32,6 +33,8 @@ class Circuitbox
       @exceptions = options.fetch(:exceptions) { [] }
       raise ArgumentError, 'exceptions need to be an array'.freeze unless @exceptions.is_a?(Array)
       @exceptions = [Timeout::Error] if @exceptions.empty?
+      use_unsafe_timeout = options.fetch(:use_unsafe_timeout, true)
+      @should_use_ruby_timeout = @exceptions.include?(Timeout::Error) && use_unsafe_timeout
 
       @logger     = options.fetch(:logger) { Circuitbox.default_logger }
       @time_class = options.fetch(:time_class) { Time }
@@ -56,7 +59,7 @@ class Circuitbox
 
         begin
           response = execution_timer.time(service, notifier, :execution_time) do
-            if exceptions.include? Timeout::Error
+            if @should_use_ruby_timeout
               timeout_seconds = run_options.fetch(:timeout_seconds) { option_value(:timeout_seconds) }
               Timeout::timeout(timeout_seconds) { yield }
             else

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -58,7 +58,7 @@ class Circuitbox
           response = execution_timer.time(service, notifier, :execution_time) do
             if exceptions.include? Timeout::Error
               timeout_seconds = run_options.fetch(:timeout_seconds) { option_value(:timeout_seconds) }
-              timeout(timeout_seconds) { yield }
+              Timeout::timeout(timeout_seconds) { yield }
             else
               yield
             end
@@ -217,10 +217,6 @@ class Circuitbox
 
     def storage_key(key)
       "circuits:#{service}:#{key}"
-    end
-
-    def timeout(timeout_seconds)
-      Timeout::timeout(timeout_seconds) { yield }
     end
   end
 end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -234,13 +234,13 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_should_use_timeout_class_if_exceptions_are_not_defined
     circuit = Circuitbox::CircuitBreaker.new(:yammer, timeout_seconds: 45)
-    circuit.expects(:timeout).with(45).once
+    Timeout.expects(:timeout).with(45).once
     emulate_circuit_run(circuit, :success, StandardError)
   end
 
   def test_should_not_use_timeout_class_if_custom_exceptions_are_defined
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [ConnectionError])
-    circuit.expects(:timeout).never
+    Timeout.expects(:timeout).never
     emulate_circuit_run(circuit, :success, StandardError)
   end
 
@@ -252,7 +252,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_timeout_seconds_run_options_overrides_circuit_options
     circuit = Circuitbox::CircuitBreaker.new(:yammer, timeout_seconds: 60)
-    circuit.expects(:timeout).with(30).once
+    Timeout.expects(:timeout).with(30).once
     circuit.run(timeout_seconds: 30) { true }
   end
 

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -244,6 +244,12 @@ class CircuitBreakerTest < Minitest::Test
     emulate_circuit_run(circuit, :success, StandardError)
   end
 
+  def test_should_not_use_timeout_if_use_unsafe_timeout_false
+    circuit = Circuitbox::CircuitBreaker.new(:yammer, use_unsafe_timeout: false)
+    Timeout.expects(:timeout).never
+    emulate_circuit_run(circuit, :success, StandardError)
+  end
+
   def test_should_return_response_if_it_doesnt_timeout
     circuit = Circuitbox::CircuitBreaker.new(:yammer)
     response = emulate_circuit_run(circuit, :success, 'success')


### PR DESCRIPTION
Currently when tracking Timeout::Error (the default if no exceptions are passed) the slower code path through ruby timeout is taken. There are cases where doing the timeout in circuitbox may not make sense, like if Timeout::Error is being re-raised.

This may make it easier to transition existing circuits away from using timeout over time.