### PR TITLE
Cleaned up undefined instance variable warnings

### DIFF
--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -86,26 +86,21 @@ class Circuitbox
     end
 
     def circuit_breaker_options
-      return @circuit_breaker_options if @circuit_breaker_options
-
-      @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
-      @circuit_breaker_options.merge!(
-        exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
-      )
+      @circuit_breaker_options ||= begin
+        options = opts.fetch(:circuit_breaker_options, {})
+        options.merge!(
+          exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
+        )
+      end
     end
 
     def default_value
-      return @default_value if @default_value
-
-      default = opts.fetch(:default_value) do
-        lambda { |response, exception| NullResponse.new(response, exception) }
+      @default_value ||= begin
+        default = opts.fetch(:default_value) do
+          lambda { |response, exception| NullResponse.new(response, exception) }
+        end
+        default.respond_to?(:call) ? default : lambda { |*| default }
       end
-
-      @default_value = if default.respond_to?(:call)
-                         default
-                       else
-                         lambda { |*| default }
-                       end
     end
   end
 end

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -66,26 +66,21 @@ class Circuitbox
     end
 
     def circuit_breaker_options
-      return @circuit_breaker_options if @circuit_breaker_options
-
-      @circuit_breaker_options = opts.fetch(:circuit_breaker_options, {})
-      @circuit_breaker_options.merge!(
-        exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
-      )
+      @circuit_breaker_options ||= begin
+        options = opts.fetch(:circuit_breaker_options, {})
+        options.merge!(
+          exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
+        )
+      end
     end
 
     def default_value
-      return @default_value if @default_value
-
-      default = opts.fetch(:default_value) do
-        lambda { |service_response, exception| NullResponse.new(service_response, exception) }
+      @default_value ||= begin
+        default = opts.fetch(:default_value) do
+          lambda { |service_response, exception| NullResponse.new(service_response, exception) }
+        end
+        default.respond_to?(:call) ? default : lambda { |*| default }
       end
-
-      @default_value = if default.respond_to?(:call)
-                         default
-                       else
-                         lambda { |*| default }
-                       end
     end
 
     def open_circuit?(response)


### PR DESCRIPTION
Unit test output was hard to read, had a lot of warnings in it. This
code is functionally the same but doesn't trigger those warnings. :)

```

/Users/psturgeon/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/moneta-1.0.0/lib/moneta/expires.rb:31:
warning: assigned but unused variable - expires
................../Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
/Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:78:
warning: instance variable @default_value not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
../Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
./Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
../Users/psturgeon/src/circuitbox/lib/circuitbox/faraday_middleware.rb:69:
warning: instance variable @circuit_breaker_options not initialized
...../Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E./Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E./Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E/Users/psturgeon/src/circuitbox/lib/circuitbox/excon_middleware.rb:89:
warning: instance variable @circuit_breaker_options not initialized
E.....................................

Finished in 0.070928s, 1226.5960 runs/s, 1494.4733 assertions/s.
```