### PR TITLE
Register Faraday middleware

### DIFF
--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -114,3 +114,5 @@ class Circuitbox
     end
   end
 end
+
+Faraday::Middleware.register_middleware circuitbox: Circuitbox::FaradayMiddleware


### PR DESCRIPTION
Allows folks to just write  instead of the class names. This allows you to change things internally a bit without messing up the middleware usage.