### PR TITLE
set expiry on notify_and_increment_event

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -186,7 +186,7 @@ class Circuitbox
     # Send notification and increment stat store
     def notify_and_increment_event(event)
       notify_event(event)
-      circuit_store.increment(stat_storage_key(event))
+      circuit_store.increment(stat_storage_key(event), 1, expires: (option_value(:time_window) * 2))
     end
 
     def log_metrics(error_rate, failures, successes)


### PR DESCRIPTION
This change comes about because the notify_and_increment_event stats key that gets stored is stored with the aligned time window and never deleted when the window changes. This means the data probably stays around for quite some time even though it would never be used again. This hopefully allows caches to clear this out not too long after it's done being used.

I randomly picked 2x the time_window for the expiry, it could probably be smaller or we could look at setting it to the time window.

This has a slight perf hit on circuitbox because we have to get the option value again, multiply it (this is a really small perf hit), and then internally the options hash is created.