### PR TITLE
Remove circuitbox's ability to timeout blocks of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,13 +308,6 @@ c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response, error| .
 c.use Circuitbox::FaradayMiddleware, identifier: "service_name_circuit"
 ```
 
-* `circuit_breaker_run_options` options passed to the circuit run method, see
-  the main circuitbreaker for those.
-
-```ruby
-conn.get("/api", circuit_breaker_run_options: {})
-```
-
 * `circuit_breaker_options` options to initialize the circuit with defaults to
   `{ volume_threshold: 10, exceptions: Circuitbox::FaradayMiddleware::DEFAULT_EXCEPTIONS }`
 

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'logger'
-require 'timeout'
 
 require_relative 'circuitbox/version'
 require_relative 'circuitbox/circuit_breaker'

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -17,7 +17,7 @@ class Circuitbox
     # `sleep_window`      - seconds to sleep the circuit
     # `volume_threshold`  - number of requests before error rate calculation occurs
     # `error_threshold`   - percentage of failed requests needed to trip circuit
-    # `exceptions`        - exceptions other than Timeout::Error that count as failures
+    # `exceptions`        - exceptions that count as failures
     # `time_window`       - interval of time used to calculate error_rate (in seconds) - default is 60s
     # `logger`            - Logger to use - defaults to Rails.logger if defined, otherwise STDOUT
     #
@@ -28,9 +28,8 @@ class Circuitbox
       @execution_timer = options.fetch(:execution_timer) { Circuitbox.default_timer }
       @notifier = options.fetch(:notifier) { Circuitbox.default_notifier }
 
-      @exceptions = options.fetch(:exceptions) { [] }
+      @exceptions = options.fetch(:exceptions)
       raise ArgumentError, 'exceptions need to be an array'.freeze unless @exceptions.is_a?(Array)
-      @exceptions = [Timeout::Error] if @exceptions.empty?
 
       @logger     = options.fetch(:logger) { Circuitbox.default_logger }
       @time_class = options.fetch(:time_class) { Time }

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -42,7 +42,7 @@ class Circuitbox
       value.is_a?(Proc) ? value.call : value
     end
 
-    def run!(run_options = {})
+    def run!
       currently_open = open_flag?
       if currently_open || should_open?
         logger.debug "[CIRCUIT] open: skipping #{service}"
@@ -70,8 +70,8 @@ class Circuitbox
       response
     end
 
-    def run(run_options = {})
-      run!(run_options, &Proc.new)
+    def run
+      run! { yield }
     rescue Circuitbox::Error
       nil
     end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -7,7 +7,6 @@ class Circuitbox
       sleep_window:     300,
       volume_threshold: 5,
       error_threshold:  50,
-      timeout_seconds:  1,
       time_window:      60
     }.freeze
 
@@ -27,6 +26,11 @@ class Circuitbox
       @circuit_store   = options.fetch(:cache) { Circuitbox.default_circuit_store }
       @execution_timer = options.fetch(:execution_timer) { Circuitbox.default_timer }
       @notifier = options.fetch(:notifier) { Circuitbox.default_notifier }
+
+      if @circuit_options[:timeout_seconds]
+        warn('timeout_seconds was removed in circuitbox 2.0. '\
+             'Check the upgrade guide at https://github.com/yammer/circuitbox'.freeze)
+      end
 
       @exceptions = options.fetch(:exceptions)
       raise ArgumentError, 'exceptions need to be an array'.freeze unless @exceptions.is_a?(Array)

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -17,7 +17,6 @@ class Circuitbox
     # `sleep_window`      - seconds to sleep the circuit
     # `volume_threshold`  - number of requests before error rate calculation occurs
     # `error_threshold`   - percentage of failed requests needed to trip circuit
-    # `timeout_seconds`   - seconds until it will timeout the request
     # `exceptions`        - exceptions other than Timeout::Error that count as failures
     # `time_window`       - interval of time used to calculate error_rate (in seconds) - default is 60s
     # `logger`            - Logger to use - defaults to Rails.logger if defined, otherwise STDOUT
@@ -56,12 +55,7 @@ class Circuitbox
 
         begin
           response = execution_timer.time(service, notifier, :execution_time) do
-            if exceptions.include? Timeout::Error
-              timeout_seconds = run_options.fetch(:timeout_seconds) { option_value(:timeout_seconds) }
-              timeout(timeout_seconds) { yield }
-            else
-              yield
-            end
+            yield
           end
           logger.debug "[CIRCUIT] closed: #{service} query success"
           success!
@@ -217,10 +211,6 @@ class Circuitbox
 
     def storage_key(key)
       "circuits:#{service}:#{key}"
-    end
-
-    def timeout(timeout_seconds)
-      Timeout::timeout(timeout_seconds) { yield }
     end
   end
 end

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -32,7 +32,7 @@ class Circuitbox
     end
 
     def error_call(datum)
-      circuit(datum).run!(run_options(datum)) do
+      circuit(datum).run! do
         raise RequestFailed
       end
     rescue Circuitbox::Error => exception
@@ -40,13 +40,13 @@ class Circuitbox
     end
 
     def request_call(datum)
-      circuit(datum).run!(run_options(datum)) do
+      circuit(datum).run! do
         @stack.request_call(datum)
       end
     end
 
     def response_call(datum)
-      circuit(datum).run!(run_options(datum)) do
+      circuit(datum).run! do
         raise RequestFailed if open_circuit?(datum[:response])
       end
       @stack.response_call(datum)
@@ -67,10 +67,6 @@ class Circuitbox
     def circuit(datum)
       id = identifier.respond_to?(:call) ? identifier.call(datum) : identifier
       circuitbox.circuit id, circuit_breaker_options
-    end
-
-    def run_options(datum)
-      opts.merge(datum)[:circuit_breaker_run_options] || {}
     end
 
     def open_circuit?(response)

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -38,7 +38,7 @@ class Circuitbox
 
     def call(request_env)
       service_response = nil
-      circuit(request_env).run!(run_options(request_env)) do
+      circuit(request_env).run! do
         @app.call(request_env).on_complete do |env|
           service_response = Faraday::Response.new(env)
           raise RequestFailed if open_circuit?(service_response)
@@ -60,10 +60,6 @@ class Circuitbox
     end
 
     private
-
-    def run_options(env)
-      env[:circuit_breaker_run_options] || {}
-    end
 
     def circuit_breaker_options
       @circuit_breaker_options ||= begin

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -246,12 +246,6 @@ class CircuitBreakerTest < Minitest::Test
     assert_equal 'success', response
   end
 
-  def test_timeout_seconds_run_options_overrides_circuit_options
-    circuit = Circuitbox::CircuitBreaker.new(:yammer, timeout_seconds: 60)
-    circuit.expects(:timeout).with(30).once
-    circuit.run(timeout_seconds: 30) { true }
-  end
-
   def test_catches_connection_error_failures_if_defined
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [ConnectionError])
     response = emulate_circuit_run(circuit, :failure, ConnectionError)

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -27,8 +27,7 @@ class CircuitBreakerTest < Minitest::Test
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                 sleep_window: 300,
                                                 volume_threshold: 5,
-                                                error_threshold: 33,
-                                                timeout_seconds: 1)
+                                                error_threshold: 33)
     end
 
     def test_open_circuit_on_100_percent_failure
@@ -182,8 +181,7 @@ class CircuitBreakerTest < Minitest::Test
                                                 sleep_window: 1,
                                                 time_window: 2,
                                                 volume_threshold: 5,
-                                                error_threshold: 5,
-                                                timeout_seconds: 1)
+                                                error_threshold: 5)
     end
 
     def test_circuit_closes_after_sleep_time_window
@@ -233,15 +231,13 @@ class CircuitBreakerTest < Minitest::Test
   end
 
   def test_should_use_timeout_class_if_exceptions_are_not_defined
-    circuit = Circuitbox::CircuitBreaker.new(:yammer, timeout_seconds: 45)
-    circuit.expects(:timeout).with(45).once
-    emulate_circuit_run(circuit, :success, StandardError)
+    circuit = Circuitbox::CircuitBreaker.new(:yammer)
+    assert_equal [Timeout::Error], circuit.exceptions
   end
 
   def test_should_not_use_timeout_class_if_custom_exceptions_are_defined
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [ConnectionError])
-    circuit.expects(:timeout).never
-    emulate_circuit_run(circuit, :success, StandardError)
+    assert_equal [ConnectionError], circuit.exceptions
   end
 
   def test_should_return_response_if_it_doesnt_timeout

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -49,18 +49,20 @@ class CircuitboxTest < Minitest::Test
   end
 
   def test_creates_a_circuit_breaker
-    assert Circuitbox[:yammer].is_a? Circuitbox::CircuitBreaker
+    assert Circuitbox[:yammer, exceptions: [Timeout::Error]].is_a? Circuitbox::CircuitBreaker
   end
 
   def test_returns_the_same_circuit_every_time
-    assert_equal Circuitbox.circuit(:yammer), Circuitbox.circuit(:yammer)
+    assert_equal Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]),
+                 Circuitbox.circuit(:yammer, exceptions: [Timeout::Error])
   end
 
   def test_sets_the_circuit_options_the_first_time_only
-    circuit_one = Circuitbox.circuit(:yammer, sleep_window: 1337)
-    circuit_two = Circuitbox.circuit(:yammer, sleep_window: 2000)
+    circuit_one = Circuitbox.circuit(:yammer, exceptions: [Timeout::Error], sleep_window: 1337)
+    circuit_two = Circuitbox.circuit(:yammer, exceptions: [StandardError], sleep_window: 2000)
 
     assert_equal 1337, circuit_one.option_value(:sleep_window)
     assert_equal 1337, circuit_two.option_value(:sleep_window)
+    assert_equal [Timeout::Error], circuit_two.exceptions
   end
 end

--- a/test/excon_middleware_test.rb
+++ b/test/excon_middleware_test.rb
@@ -28,7 +28,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com' }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       default_value_generator = ->(_, _) { :sential }
       middleware = ExconMiddleware.new(app,
                                        circuitbox: circuitbox,
@@ -40,7 +40,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com' }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
       assert_equal :sential, middleware.error_call(env)
     end
@@ -78,16 +78,6 @@ class Circuitbox
       assert_includes middleware.exceptions, SentialException
     end
 
-    def test_pass_circuit_breaker_run_options
-      stub_circuitbox
-      give(circuit).run!(:sential)
-      give(circuitbox).circuit('yammer.com', anything) { circuit }
-      env = { host: 'yammer.com', circuit_breaker_run_options: :sential }
-      middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
-      middleware.request_call(env)
-      verify(circuit, 1.times).run!(:sential)
-    end
-
     def test_pass_circuit_breaker_options
       stub_circuitbox
       env = { host: 'yammer.com' }
@@ -107,7 +97,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com', circuit_breaker_default_value: :sential }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.error_call(env), :sential
     end
@@ -115,7 +105,7 @@ class Circuitbox
     def test_return_null_response_for_open_circuit
       stub_circuitbox
       env = { host: 'yammer.com' }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       mw = ExconMiddleware.new(app, circuitbox: circuitbox)
       response = mw.error_call(env)

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -28,7 +28,7 @@ class Circuitbox
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       default_value_generator = lambda { |response| :sential }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
@@ -40,7 +40,7 @@ class Circuitbox
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error, 'error text' }
+      give(circuit).run! { raise Circuitbox::Error, 'error text' }
       default_value_generator = ->(_, error) { error.message }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
@@ -52,7 +52,7 @@ class Circuitbox
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
       assert_equal :sential, middleware.call(env)
     end
@@ -113,16 +113,6 @@ class Circuitbox
       assert_includes middleware.exceptions, SentialException
     end
 
-    def test_pass_circuit_breaker_run_options
-      stub_circuitbox
-      give(circuit).run!(:sential)
-      give(circuitbox).circuit('yammer.com', anything) { circuit }
-      env = { url: URI('http://yammer.com/'), circuit_breaker_run_options: :sential }
-      middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
-      middleware.call(env)
-      verify(circuit, 1.times).run!(:sential)
-    end
-
     def test_pass_circuit_breaker_options
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
@@ -142,7 +132,7 @@ class Circuitbox
       stub_circuitbox
       env = { url: URI('http://yammer.com/'), circuit_breaker_default_value: :sential }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.call(env), :sential
     end
@@ -150,7 +140,7 @@ class Circuitbox
     def test_return_value_closed_circuit
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
-      give(circuit).run!(anything) { :sential }
+      give(circuit).run! { :sential }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       middleware = FaradayMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.call(env), :sential
@@ -159,7 +149,7 @@ class Circuitbox
     def test_return_null_response_for_open_circuit
       stub_circuitbox
       env = { url: URI('http://yammer.com/') }
-      give(circuit).run!(anything) { raise Circuitbox::Error }
+      give(circuit).run! { raise Circuitbox::Error }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       response = FaradayMiddleware.new(app, circuitbox: circuitbox).call(env)
       assert_kind_of Faraday::Response, response


### PR DESCRIPTION
While circuitbox handling timeouts may seem useful it opens up very hard to track down bugs. There are many ruby examples on the issues that can arise when using ```Timeout::timeout```.

This change also removes the runtime_opts from ```run!``` and ```run``` because that was only used for timeout. ```exceptions:``` is also a required option now.