### PR TITLE
Lower default sleep_window

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -4,7 +4,7 @@ class Circuitbox
                 :logger, :circuit_store, :notifier, :time_class, :execution_timer
 
     DEFAULTS = {
-      sleep_window:     300,
+      sleep_window:     90,
       volume_threshold: 5,
       error_threshold:  50,
       timeout_seconds:  1,


### PR DESCRIPTION
This is currently set to 300 seconds (5 minutes) which seems like an awfully long time to wait to even try the service again. Lowering this to 90 seconds will cause us to hit the half open state more often but also means the circuit (default settings) has the ability to close sooner.