### PR TITLE
Don't overwrite sleep_window when the value is less than time_window

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -37,7 +37,7 @@ class Circuitbox
 
       @logger     = options.fetch(:logger) { Circuitbox.default_logger }
       @time_class = options.fetch(:time_class) { Time }
-      sanitize_options
+      check_sleep_window
     end
 
     def option_value(name)
@@ -192,12 +192,14 @@ class Circuitbox
       notifier.metric_gauge(service, :success_count, successes)
     end
 
-    def sanitize_options
+    def check_sleep_window
       sleep_window = option_value(:sleep_window)
       time_window  = option_value(:time_window)
       if sleep_window < time_window
-        notifier.notify_warning(service, "sleep_window:#{sleep_window} is shorter than time_window:#{time_window}, the error_rate could not be reset properly after a sleep. sleep_window as been set to equal time_window.")
-        @circuit_options[:sleep_window] = option_value(:time_window)
+        warning_message = "sleep_window: #{sleep_window} is shorter than time_window: #{time_window}, "\
+                          "the error_rate would not be reset after a sleep."
+        notifier.notify_warning(service, warning_message)
+        warn("Circuit: #{service}, Warning: #{warning_message}")
       end
     end
 

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -176,7 +176,7 @@ class CircuitBreakerTest < Minitest::Test
     def setup
       Circuitbox.configure { |config| config.default_circuit_store = Moneta.new(:Memory, expires: true) }
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                                sleep_window: 1,
+                                                sleep_window: 2,
                                                 time_window: 2,
                                                 volume_threshold: 5,
                                                 error_threshold: 5,
@@ -194,8 +194,9 @@ class CircuitBreakerTest < Minitest::Test
 
       assert_equal 0, run_count, 'circuit has not opened prior'
 
-      # it is + 2 on purpose, because + 1 is flaky here
-      approximate_sleep_window = @circuit.option_value(:sleep_window) + 2
+      # We need to be past the sleep window for the circuit to close
+      # which is why we are adding 1 second to the sleep window
+      approximate_sleep_window = @circuit.option_value(:sleep_window) + 1
 
       Timecop.freeze(current_time + approximate_sleep_window) do
         @circuit.run { run_count += 1 }

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -10,14 +10,6 @@ class CircuitBreakerTest < Minitest::Test
     Circuitbox.configure { |config| config.default_circuit_store = Moneta.new(:Memory, expires: true) }
   end
 
-  def test_sleep_window_is_forced_to_equal_time_window
-    circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                             sleep_window: 1,
-                                             time_window: 10,
-                                             exceptions: [Timeout::Error])
-    assert_equal circuit.option_value(:sleep_window), circuit.option_value(:time_window)
-  end
-
   def test_goes_into_half_open_state_on_sleep
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
     circuit.send(:open!)
@@ -413,12 +405,15 @@ class CircuitBreakerTest < Minitest::Test
 
     def test_warning_when_sleep_window_is_shorter_than_time_window
       notifier = gimme_notifier
-      Circuitbox::CircuitBreaker.new(:yammer,
-                                     notifier: notifier,
-                                     sleep_window: 1,
-                                     time_window: 10,
-                                     exceptions: [Timeout::Error])
+      _, error = capture_io do
+        Circuitbox::CircuitBreaker.new(:yammer,
+                                       notifier: notifier,
+                                       sleep_window: 1,
+                                       time_window: 10,
+                                       exceptions: [Timeout::Error])
+      end
       assert notifier.notified?, 'no notification sent'
+      assert_match(/Circuit: yammer.+sleep_window: 1.+time_window: 10.+/, error)
     end
 
     def test_does_not_warn_on_sleep_window_being_correctly_sized


### PR DESCRIPTION
Before this change we would set the ```sleep_window``` equal to the ```time_window``` if it were less than the ```time_window```. If the ```sleep_window``` were a proc it would get overwritten with the value of ```time_window```. We would discard the proc and use a static number from this point on.

Now we would warn, like how it was done before and also send a ```Kernel.warn```. This still only runs one time, at initialization.