### PR TITLE
Do timer calculation outside of method call

### DIFF
--- a/lib/circuitbox/timer/monotonic.rb
+++ b/lib/circuitbox/timer/monotonic.rb
@@ -8,8 +8,8 @@ class Circuitbox
       def time(service, notifier, metric_name)
         before = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
         result = yield
-        after = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit)
-        notifier.metric_gauge(service, metric_name, after - before)
+        total_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, @time_unit) - before
+        notifier.metric_gauge(service, metric_name, total_time)
         result
       end
     end

--- a/lib/circuitbox/timer/simple.rb
+++ b/lib/circuitbox/timer/simple.rb
@@ -4,8 +4,8 @@ class Circuitbox
       def time(service, notifier, metric_name)
         before = Time.now.to_f
         result = yield
-        after = Time.now.to_f
-        notifier.metric_gauge(service, metric_name, after - before)
+        total_time = Time.now.to_f - before
+        notifier.metric_gauge(service, metric_name, total_time)
         result
       end
     end


### PR DESCRIPTION
After a block has been timed calculate the total time and pass the result to the metric_gauge.