### PR TITLE
Improvements to storage keys

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -63,7 +63,7 @@ class Circuitbox
         logger.debug(circuit_closed_querying_message)
 
         begin
-          response = execution_timer.time(service, notifier, :execution_time) do
+          response = execution_timer.time(service, notifier, 'execution_time') do
             yield
           end
           logger.debug(circuit_closed_query_success_message)
@@ -191,9 +191,9 @@ class Circuitbox
     end
 
     def log_metrics(error_rate, failures, successes)
-      notifier.metric_gauge(service, :error_rate, error_rate)
-      notifier.metric_gauge(service, :failure_count, failures)
-      notifier.metric_gauge(service, :success_count, successes)
+      notifier.metric_gauge(service, 'error_rate', error_rate)
+      notifier.metric_gauge(service, 'failure_count', failures)
+      notifier.metric_gauge(service, 'success_count', successes)
     end
 
     def check_sleep_window

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -208,7 +208,7 @@ class Circuitbox
     end
 
     def stat_storage_key(event)
-      "#{storage_key('stats'.freeze)}:#{align_time_to_window}:#{event}"
+      "circuits:#{service}:stats:#{align_time_to_window}:#{event}"
     end
 
     # return time representation in seconds

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -134,7 +134,9 @@ class Circuitbox
     end
 
     def open!
-
+      notify_event('open')
+      logger.debug(circuit_opening_message)
+      circuit_store.store(storage_key('asleep'), true, expires: option_value(:sleep_window))
       half_open!
       was_open!
     end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'circuit_breaker/logger_messages'
 
 class Circuitbox
@@ -33,11 +35,11 @@ class Circuitbox
 
       if @circuit_options[:timeout_seconds]
         warn('timeout_seconds was removed in circuitbox 2.0. '\
-             'Check the upgrade guide at https://github.com/yammer/circuitbox'.freeze)
+             'Check the upgrade guide at https://github.com/yammer/circuitbox')
       end
 
       @exceptions = options.fetch(:exceptions)
-      raise ArgumentError, 'exceptions need to be an array'.freeze unless @exceptions.is_a?(Array)
+      raise ArgumentError, 'exceptions need to be an array' unless @exceptions.is_a?(Array)
 
       @logger     = options.fetch(:logger) { Circuitbox.default_logger }
       @time_class = options.fetch(:time_class) { Time }
@@ -100,15 +102,15 @@ class Circuitbox
     end
 
     def failure_count
-      circuit_store.load(stat_storage_key(:failure), raw: true).to_i
+      circuit_store.load(stat_storage_key('failure'), raw: true).to_i
     end
 
     def success_count
-      circuit_store.load(stat_storage_key(:success), raw: true).to_i
+      circuit_store.load(stat_storage_key('success'), raw: true).to_i
     end
 
     def try_close_next_time
-      circuit_store.delete(storage_key(:asleep))
+      circuit_store.delete(storage_key('asleep'))
     end
 
   private
@@ -132,51 +134,49 @@ class Circuitbox
     end
 
     def open!
-      notify_event :open
-      logger.debug(circuit_opening_message)
-      circuit_store.store(storage_key(:asleep), true, expires: option_value(:sleep_window))
+
       half_open!
       was_open!
     end
 
     ### BEGIN - all this is just here to produce a close notification
     def close!
-      notify_event :close
-      circuit_store.delete(storage_key(:was_open))
+      notify_event('close')
+      circuit_store.delete(storage_key('was_open'))
     end
 
     def was_open!
-      circuit_store.store(storage_key(:was_open), true)
+      circuit_store.store(storage_key('was_open'), true)
     end
 
     def was_open?
-      circuit_store.key?(storage_key(:was_open))
+      circuit_store.key?(storage_key('was_open'))
     end
     ### END
 
     def half_open!
-      circuit_store.store(storage_key(:half_open), true)
+      circuit_store.store(storage_key('half_open'), true)
     end
 
     def open_flag?
-      circuit_store.key?(storage_key(:asleep))
+      circuit_store.key?(storage_key('asleep'))
     end
 
     def half_open?
-      circuit_store.key?(storage_key(:half_open))
+      circuit_store.key?(storage_key('half_open'))
     end
 
     def success!
-      notify_and_increment_event :success
-      circuit_store.delete(storage_key(:half_open))
+      notify_and_increment_event('success')
+      circuit_store.delete(storage_key('half_open'))
     end
 
     def failure!
-      notify_and_increment_event :failure
+      notify_and_increment_event('failure')
     end
 
     def skipped!
-      notify_event :skipped
+      notify_event('skipped')
     end
 
     # Send event notification to notifier

--- a/lib/circuitbox/notifier/active_support.rb
+++ b/lib/circuitbox/notifier/active_support.rb
@@ -12,7 +12,7 @@ class Circuitbox
       end
 
       def metric_gauge(circuit_name, gauge, value)
-        ::ActiveSupport::Notifications.instrument('circuit_gauge', circuit: circuit_name, gauge: gauge.to_s, value: value)
+        ::ActiveSupport::Notifications.instrument('circuit_gauge', circuit: circuit_name, gauge: gauge, value: value)
       end
     end
   end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -264,7 +264,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_records_response_failure
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    circuit.expects(:notify_and_increment_event).with(:failure)
+    circuit.expects(:notify_and_increment_event).with('failure')
     emulate_circuit_run(circuit, :failure, Timeout::Error)
   end
 
@@ -272,13 +272,13 @@ class CircuitBreakerTest < Minitest::Test
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
     circuit.stubs(should_open?: true)
     circuit.stubs(:notify_event)
-    circuit.expects(:notify_event).with(:skipped)
+    circuit.expects(:notify_event).with('skipped')
     emulate_circuit_run(circuit, :failure, Timeout::Error)
   end
 
   def test_records_response_success
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    circuit.expects(:notify_and_increment_event).with(:success)
+    circuit.expects(:notify_and_increment_event).with('success')
     emulate_circuit_run(circuit, :success, 'success')
   end
 
@@ -342,13 +342,13 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_logs_and_retrieves_success_events
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    5.times { circuit.send(:notify_and_increment_event, :success) }
+    5.times { circuit.send(:notify_and_increment_event, 'success') }
     assert_equal 5, circuit.success_count
   end
 
   def test_logs_and_retrieves_failure_events
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    5.times { circuit.send(:notify_and_increment_event, :failure) }
+    5.times { circuit.send(:notify_and_increment_event, 'failure') }
     assert_equal 5, circuit.failure_count
   end
 
@@ -357,19 +357,19 @@ class CircuitBreakerTest < Minitest::Test
     current_time = Time.new(2015, 7, 29)
 
     Timecop.freeze(current_time) do
-      4.times { circuit.send(:notify_and_increment_event, :success) }
+      4.times { circuit.send(:notify_and_increment_event, 'success') }
       assert_equal 4, circuit.success_count
     end
 
     # one minute after current_time
     Timecop.freeze(current_time + 60) do
-      7.times { circuit.send(:notify_and_increment_event, :success) }
+      7.times { circuit.send(:notify_and_increment_event, 'success') }
       assert_equal 7, circuit.success_count
     end
 
     # one minute 30 seconds after current_time
     Timecop.freeze(current_time + 90) do
-      circuit.send(:notify_and_increment_event, :success)
+      circuit.send(:notify_and_increment_event, 'success')
       assert_equal 8, circuit.success_count
     end
 
@@ -495,13 +495,13 @@ class CircuitBreakerTest < Minitest::Test
 
     def gimme_notifier(opts = {})
       service = opts.fetch(:service, 'yammer').to_s
-      metric = opts.fetch(:metric, :error_rate)
+      metric = opts.fetch(:metric, 'error_rate')
       metric_value = opts.fetch(:metric_value, 0.0)
       fake_notifier = gimme
       notified = false
       metric_sent = false
-      give(fake_notifier).notify(service, :open) { notified = true }
-      give(fake_notifier).notify(service, :close) { notified = true }
+      give(fake_notifier).notify(service, 'open') { notified = true }
+      give(fake_notifier).notify(service, 'close') { notified = true }
       give(fake_notifier).notify_warning(service, Gimme::Matchers::Anything.new) { notified = true }
       give(fake_notifier).metric_gauge(service, metric, metric_value) do
         notified = true

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -428,7 +428,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_notifies_on_success_rate_calculation
-      notifier = gimme_notifier(metric: :error_rate, metric_value: 0.0)
+      notifier = gimme_notifier(metric: 'error_rate', metric_value: 0.0)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
@@ -437,7 +437,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_notifies_on_error_rate_calculation
-      notifier = gimme_notifier(metric: :failure_count, metric_value: 1)
+      notifier = gimme_notifier(metric: 'failure_count', metric_value: 1)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
@@ -446,7 +446,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_success_count_on_error_rate_calculation
-      notifier = gimme_notifier(metric: :success_count, metric_value: 6)
+      notifier = gimme_notifier(metric: 'success_count', metric_value: 6)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
@@ -455,7 +455,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_not_notify_circuit_execution_time_on_null_timer
-      notifier = gimme_notifier(metric: :execution_time, metric_value: Gimme::Matchers::Anything.new)
+      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
       timer = Circuitbox::Timer::Null.new
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
@@ -466,7 +466,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_send_execution_time_metric
-      notifier = gimme_notifier(metric: :execution_time, metric_value: Gimme::Matchers::Anything.new)
+      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
@@ -475,7 +475,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_no_execution_time_metric_on_error_execution
-      notifier = gimme_notifier(metric: :execution_time, metric_value: Gimme::Matchers::Anything.new)
+      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
@@ -484,7 +484,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def test_no_execution_time_metric_when_circuit_open
-      notifier = gimme_notifier(metric: :execution_time, metric_value: Gimme::Matchers::Anything.new)
+      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])

--- a/test/notifier/active_support_test.rb
+++ b/test/notifier/active_support_test.rb
@@ -19,6 +19,6 @@ class NotifierActiveSupportTest < Minitest::Test
 
   def test_sends_metric_as_notification
     ActiveSupport::Notifications.expects(:instrument).with("circuit_gauge", { circuit: 'yammer', gauge: 'ratio', value: 12})
-    Circuitbox::Notifier::ActiveSupport.new.metric_gauge('yammer', :ratio, 12)
+    Circuitbox::Notifier::ActiveSupport.new.metric_gauge('yammer', 'ratio', 12)
   end
 end


### PR DESCRIPTION
Switch storage key events to frozen strings, which should avoid symbol to string conversion. Have stat_storage_key handle generating the key rather than also using storage_key. Send strings to metric_gauge since it was converting to a string anyway.