### PR TITLE
Circuitbox in memory store

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ namespace :test do
   desc 'Run unit tests'
   Rake::TestTask.new(:unit) do |t|
     t.libs << 'test'
-    t.test_files = FileList['test/*_test.rb', 'test/notifier/*_test.rb']
+    t.test_files = FileList['test/*_test.rb', 'test/notifier/*_test.rb', 'test/memory_store/*_test.rb']
   end
 
   desc 'Run integration tests'

--- a/benchmark/object_usage_benchmark.rb
+++ b/benchmark/object_usage_benchmark.rb
@@ -1,0 +1,72 @@
+# frozen-string-literal: true
+
+require 'circuitbox'
+require 'circuitbox/memory_store'
+
+##
+# This looks at the retained object counts over time of different in-memory stores
+##
+
+# configuration
+iterations_to_run_each_circuit = 5000
+frequency_to_report_object_allocations = 150
+circuits_to_test = []
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::WARN # so we don't output any debug info
+
+circuits_to_test << Circuitbox::CircuitBreaker.new('circuitbox_memory_store',
+                                                   sleep_window: 2,
+                                                   time_window: 1,
+                                                   logger: logger,
+                                                   exceptions: [StandardError],
+                                                   cache: Circuitbox::MemoryStore.new)
+
+circuits_to_test << Circuitbox::CircuitBreaker.new('moneta_memory_store',
+                                                   sleep_window: 2,
+                                                   time_window: 1,
+                                                   logger: logger,
+                                                   exceptions: [StandardError],
+                                                   cache: Moneta.new(:Memory, expires: true, threadsafe: true))
+
+class ObjectUsageBenchmark
+  class << self
+    def run(circuits, iterations, report_every)
+      circuits.each do |circuit|
+        puts "Starting object use benchmark for #{circuit.service}"
+        puts "Initial object allocations: #{current_object_allocations}"
+
+        total_iterations = 0
+
+        while total_iterations < iterations
+          total_iterations += 1
+
+          circuit.run do
+            raise StandardError if total_iterations % 4
+          end
+
+          # by sleeping we end up causing the circuit to go through
+          # multiple time_window's when the iteration count is high
+          # and the time window is low.
+          sleep 0.1
+
+          next unless (total_iterations % report_every).zero?
+
+          puts "Object report ##{total_iterations / report_every}: #{current_object_allocations}"
+        end
+
+        puts "Final object allocations for #{circuit.service}: #{current_object_allocations}"
+      end
+    end
+
+  private
+
+    def current_object_allocations
+      GC.start
+      objects = ObjectSpace.count_objects
+      "Strings: #{objects[:T_STRING]}, Arrays: #{objects[:T_ARRAY]}, Objects: #{objects[:T_OBJECT]}, Hashes: #{objects[:T_HASH]}"
+    end
+  end
+end
+
+ObjectUsageBenchmark.run(circuits_to_test, iterations_to_run_each_circuit, frequency_to_report_object_allocations)

--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -21,8 +21,9 @@ class Circuitbox
     end
 
     def increment(key, amount = 1, opts = {})
+      seconds_to_expire = opts.fetch(:expires, 0)
+
       @mutex.synchronize do
-        seconds_to_expire = opts.fetch(:expires, 0)
         existing_container = fetch_container(key)
 
         # reusing the existing container is a small optmization

--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -7,7 +7,7 @@ class Circuitbox
   class MemoryStore
     include MonotonicTime
 
-    def initialize(compaction_frequency: 10)
+    def initialize(compaction_frequency: 60)
       @store = {}
       @mutex = Mutex.new
       @compactor = Compactor.new(store: @store, frequency: compaction_frequency)

--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -1,0 +1,75 @@
+# frozen-string-literal: true
+
+require_relative 'memory_store/compactor'
+require_relative 'memory_store/container'
+
+class Circuitbox
+  class MemoryStore
+    include MonotonicTime
+
+    def initialize(compaction_frequency: 10)
+      @store = {}
+      @mutex = Mutex.new
+      @compactor = Compactor.new(store: @store, frequency: compaction_frequency)
+    end
+
+    def store(key, value, opts = {})
+      @mutex.synchronize do
+        @store[key] = Container.new(value: value, expiry: opts.fetch(:expires, 0))
+        value
+      end
+    end
+
+    def increment(key, amount = 1, opts = {})
+      @mutex.synchronize do
+        seconds_to_expire = opts.fetch(:expires, 0)
+        existing_container = fetch_container(key)
+
+        # reusing the existing container is a small optmization
+        # to reduce the amount of objects created
+        if existing_container
+          existing_container.expires_after(seconds_to_expire)
+          existing_container.value += amount
+        else
+          @store[key] = Container.new(value: amount, expiry: seconds_to_expire)
+          amount
+        end
+      end
+    end
+
+    def load(key, _opts = {})
+      @mutex.synchronize { fetch_value(key) }
+    end
+
+    def key?(key)
+      @mutex.synchronize { !fetch_container(key).nil? }
+    end
+
+    def delete(key)
+      @mutex.synchronize { @store.delete(key) }
+    end
+
+  private
+
+    def fetch_container(key)
+      @compactor.run
+
+      container = @store[key]
+
+      return unless container
+
+      if container.expired?
+        @store.delete(key)
+        nil
+      else
+        container
+      end
+    end
+
+    def fetch_value(key)
+      container = fetch_container(key)
+      return unless container
+      container.value
+    end
+  end
+end

--- a/lib/circuitbox/memory_store/compactor.rb
+++ b/lib/circuitbox/memory_store/compactor.rb
@@ -16,9 +16,11 @@ class Circuitbox
       end
 
       def run
-        return unless compact_after < current_second
+        compaction_attempted_at = current_second
 
-        @store.delete_if { |_, value| value.expired? }
+        return unless compact_after < compaction_attempted_at
+
+        @store.delete_if { |_, value| value.expired_at?(compaction_attempted_at) }
 
         set_next_compaction_time
       end

--- a/lib/circuitbox/memory_store/compactor.rb
+++ b/lib/circuitbox/memory_store/compactor.rb
@@ -1,0 +1,33 @@
+# frozen-string-literal: true
+
+require_relative 'monotonic_time'
+
+class Circuitbox
+  class MemoryStore
+    class Compactor
+      include MonotonicTime
+
+      attr_reader :store, :frequency, :compact_after
+
+      def initialize(store:, frequency:)
+        @store = store
+        @frequency = frequency
+        set_next_compaction_time
+      end
+
+      def run
+        return unless compact_after < current_second
+
+        @store.delete_if { |_, value| value.expired? }
+
+        set_next_compaction_time
+      end
+
+    private
+
+      def set_next_compaction_time
+        @compact_after = current_second + frequency
+      end
+    end
+  end
+end

--- a/lib/circuitbox/memory_store/container.rb
+++ b/lib/circuitbox/memory_store/container.rb
@@ -1,0 +1,24 @@
+require_relative 'monotonic_time'
+
+class Circuitbox
+  class MemoryStore
+    class Container
+      include MonotonicTime
+
+      attr_accessor :value
+
+      def initialize(value:, expiry: 0)
+        @value = value
+        expires_after(expiry)
+      end
+
+      def expired?
+        @expires_after.positive? && @expires_after < current_second
+      end
+
+      def expires_after(seconds = 0)
+        @expires_after = seconds.zero? ? seconds : current_second + seconds
+      end
+    end
+  end
+end

--- a/lib/circuitbox/memory_store/container.rb
+++ b/lib/circuitbox/memory_store/container.rb
@@ -13,7 +13,7 @@ class Circuitbox
       end
 
       def expired?
-        @expires_after.positive? && @expires_after < current_second
+        @expires_after > 0 && @expires_after < current_second
       end
 
       def expires_after(seconds = 0)

--- a/lib/circuitbox/memory_store/container.rb
+++ b/lib/circuitbox/memory_store/container.rb
@@ -16,6 +16,10 @@ class Circuitbox
         @expires_after > 0 && @expires_after < current_second
       end
 
+      def expired_at?(clock_second)
+        @expires_after > 0 && @expires_after < clock_second
+      end
+
       def expires_after(seconds = 0)
         @expires_after = seconds.zero? ? seconds : current_second + seconds
       end

--- a/lib/circuitbox/memory_store/monotonic_time.rb
+++ b/lib/circuitbox/memory_store/monotonic_time.rb
@@ -1,0 +1,11 @@
+class Circuitbox
+  class MemoryStore
+    module MonotonicTime
+      module_function
+
+      def current_second
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      end
+    end
+  end
+end

--- a/test/integration/memory_store_test.rb
+++ b/test/integration/memory_store_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'circuitbox/memory_store'
+
+class MemoryStoreTest < Minitest::Test
+  def setup
+    @memory_store = Circuitbox::MemoryStore.new
+  end
+
+  def test_load_returns_nil_when_expired
+    @memory_store.store('test_key', 'test_value', expires: 1)
+
+    sleep 2
+
+    assert_nil @memory_store.load('test_key')
+  end
+
+  def test_load_returns_value_when_not_expired
+    @memory_store.store('test_key', 'test_value', expires: 10)
+
+    assert_equal 'test_value', @memory_store.load('test_key')
+  end
+
+  def test_key_returns_false_when_expired
+    @memory_store.store('test_key', 'test_value', expires: 1)
+
+    sleep 2
+
+    assert_equal false, @memory_store.key?('test_key')
+  end
+
+  def test_key_returns_true_when_not_expired
+    @memory_store.store('test_key', 'test_value', expires: 10)
+
+    assert @memory_store.key?('test_key')
+  end
+end

--- a/test/memory_store/compactor_test.rb
+++ b/test/memory_store/compactor_test.rb
@@ -36,7 +36,7 @@ class MemoryStoreCompactorTest < Minitest::Test
 
   def test_run_checks_if_value_is_expired_when_compacting
     value_mock = mock
-    value_mock.expects(:expired?).returns(true)
+    value_mock.expects(:expired_at?).returns(true)
     store = { 'test' => value_mock }
 
     compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 2)

--- a/test/memory_store/compactor_test.rb
+++ b/test/memory_store/compactor_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+require 'circuitbox/memory_store/compactor'
+
+class MemoryStoreCompactorTest < Minitest::Test
+  def test_initialize_sets_store
+    store = mock
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 1)
+    assert_equal store, compactor.store
+  end
+
+  def test_initialize_sets_frequency
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: {}, frequency: 2)
+    assert_equal 2, compactor.frequency
+  end
+
+  def test_initialize_sets_compact_after
+    Circuitbox::MemoryStore::Compactor.any_instance
+                                      .stubs(:current_second)
+                                      .returns(1)
+
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: {}, frequency: 2)
+    assert_equal 3, compactor.compact_after
+  end
+
+  def test_run_does_not_compact_when_compact_after_has_not_passed
+    store = mock
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 2)
+
+    current_second = compactor.compact_after - 1
+
+    compactor.stubs(:current_second).returns(current_second)
+    store.expects(:delete_if).never
+
+    compactor.run
+  end
+
+  def test_run_checks_if_value_is_expired_when_compacting
+    value_mock = mock
+    value_mock.expects(:expired?).returns(true)
+    store = { 'test' => value_mock }
+
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 2)
+
+    compactor.stubs(:current_second).returns(compactor.compact_after + 1)
+
+    compactor.run
+  end
+
+  def test_run_sets_compact_after_when_compaction_complete
+    Circuitbox::MemoryStore::Compactor.any_instance
+                                      .stubs(:current_second)
+                                      .returns(1)
+    store = mock
+    store.stubs(:delete_if)
+
+    compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 2)
+
+    current_second = compactor.compact_after + 1
+    compactor.stubs(:current_second).returns(compactor.compact_after + 1)
+
+    compactor.run
+
+    assert_equal current_second + 2, compactor.compact_after
+  end
+end

--- a/test/memory_store/compactor_test.rb
+++ b/test/memory_store/compactor_test.rb
@@ -36,12 +36,14 @@ class MemoryStoreCompactorTest < Minitest::Test
 
   def test_run_checks_if_value_is_expired_when_compacting
     value_mock = mock
-    value_mock.expects(:expired_at?).returns(true)
     store = { 'test' => value_mock }
 
     compactor = Circuitbox::MemoryStore::Compactor.new(store: store, frequency: 2)
 
-    compactor.stubs(:current_second).returns(compactor.compact_after + 1)
+    current_second_value = compactor.compact_after + 1
+
+    compactor.stubs(:current_second).returns(current_second_value)
+    value_mock.expects(:expired_at?).with(current_second_value).returns(true)
 
     compactor.run
   end

--- a/test/memory_store/container_test.rb
+++ b/test/memory_store/container_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'circuitbox/memory_store/container'
+
+class MemoryStoreContainerTest < Minitest::Test
+  def test_initialize_sets_the_value
+    container = Circuitbox::MemoryStore::Container.new(value: 'test')
+    assert_equal 'test', container.value
+  end
+
+  def test_initialize_sets_default_expiry
+    Circuitbox::MemoryStore::Container.any_instance
+                                      .expects(:expires_after)
+                                      .with(0)
+
+    Circuitbox::MemoryStore::Container.new(value: 'test')
+  end
+
+  def test_initialize_sets_custom_expiry
+    Circuitbox::MemoryStore::Container.any_instance
+                                      .expects(:expires_after)
+                                      .with(5)
+
+    Circuitbox::MemoryStore::Container.new(value: 'test', expiry: 5)
+  end
+
+  def test_expired_returns_false_when_expiry_is_zero
+    container = Circuitbox::MemoryStore::Container.new(value: 'test')
+    container.expects(:current_second).never
+
+    assert_equal false, container.expired?
+  end
+
+  def test_expired_returns_false_when_value_is_still_valid
+    container = Circuitbox::MemoryStore::Container.new(value: 'test', expiry: 1)
+    container.expects(:current_second).returns(2).twice
+    container.expires_after(2)
+
+    assert_equal false, container.expired?
+  end
+
+  def test_expired_returns_true_when_value_has_expired
+    container = Circuitbox::MemoryStore::Container.new(value: 'test')
+    container.expects(:current_second).returns(1)
+    container.expires_after(5)
+
+    # move the time up to after the value should expire
+    container.expects(:current_second).returns(7)
+
+    assert container.expired?
+  end
+end

--- a/test/memory_store_test.rb
+++ b/test/memory_store_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'circuitbox/memory_store'
+
+class MemoryStoreTest < Minitest::Test
+  def setup
+    @compactor = mock
+    @compactor.stubs(:run)
+    Circuitbox::MemoryStore::Compactor.stubs(:new)
+                                      .returns(@compactor)
+    @memory_store = Circuitbox::MemoryStore.new
+  end
+
+  def test_store_returns_value_being_stored
+    return_value = @memory_store.store('test', 5)
+    assert_equal 5, return_value
+  end
+
+  def test_store_default_expires_zero
+    Circuitbox::MemoryStore::Container.expects(:new)
+                                      .with(value: 5, expiry: 0)
+    @memory_store.store('test', 5)
+  end
+
+  def test_store_allows_custom_expires
+    Circuitbox::MemoryStore::Container.expects(:new)
+                                      .with(value: 5, expiry: 10)
+    @memory_store.store('test', 5, expires: 10)
+  end
+
+  def test_increment_default_amount_is_one
+    return_value = @memory_store.increment('test')
+    assert_equal 1, return_value
+  end
+
+  def test_increment_allows_custom_amount
+    return_value = @memory_store.increment('test', 5)
+    assert_equal 5, return_value
+  end
+
+  def test_increment_can_be_called_on_existing_key
+    @memory_store.store('test', 1)
+    assert_equal 2, @memory_store.increment('test')
+  end
+
+  def test_increment_passes_expires_to_container
+    Circuitbox::MemoryStore::Container.expects(:new)
+                                      .with(value: 1, expiry: 2)
+
+    @memory_store.increment('test', 1, expires: 2)
+  end
+
+  def test_increment_default_expires_is_zero
+    Circuitbox::MemoryStore::Container.expects(:new)
+                                      .with(value: 1, expiry: 0)
+
+    @memory_store.increment('test')
+  end
+
+  def test_increment_updates_expires_on_existing_key
+    container = mock
+    container.stubs(:expired? => false, :value => 1, :value= => 2)
+    container.expects(:expires_after).with(5)
+
+    Circuitbox::MemoryStore::Container.stubs(:new)
+                                      .returns(container)
+
+    @memory_store.increment('test') # creates new key
+    @memory_store.increment('test', 1, expires: 5) # updates existing key
+  end
+
+  def test_increment_attempts_a_compaction
+    @compactor.expects(:run)
+    @memory_store.increment('test')
+  end
+
+  def test_load_returns_the_value_of_a_key
+    @memory_store.store('test', 1234)
+    assert_equal 1234, @memory_store.load('test')
+  end
+
+  def test_load_returns_nil_when_key_not_set
+    assert_nil @memory_store.load('test')
+  end
+
+  def test_load_returns_nil_when_key_expired
+    container = mock
+    container.stubs(:value= => 1234, :value => 1234)
+    Circuitbox::MemoryStore::Container.stubs(:new)
+                                      .returns(container)
+    @memory_store.store('test', 1234)
+
+    container.expects(:expired?).returns(true)
+
+    assert_nil @memory_store.load('test')
+  end
+
+  def test_load_attempts_a_compaction
+    @compactor.expects(:run)
+    @memory_store.load('test')
+  end
+
+  def test_key_returns_true_when_key_is_set
+    @memory_store.store('test', 1)
+    assert @memory_store.key?('test')
+  end
+
+  def test_key_returns_false_when_key_is_not_set
+    assert_equal false, @memory_store.key?('test')
+  end
+
+  def test_key_returns_false_when_key_is_expired
+    container = mock
+    container.stubs(:value= => 1, :value => 1)
+    Circuitbox::MemoryStore::Container.stubs(:new)
+                                      .returns(container)
+    @memory_store.store('test', 1)
+    container.expects(:expired?).returns(true)
+    assert_equal false, @memory_store.key?('test')
+  end
+
+  def test_delete_removes_key
+    @memory_store.store('test', 1)
+
+    @memory_store.delete('test')
+    assert_equal false, @memory_store.key?('test')
+  end
+end


### PR DESCRIPTION
Why a different in-memory store?
The way circuitbox stores stats keys is problematic with how Moneta's in-memory store handles expiry (this is not a fault of Moneta). What happens is old stats keys sit around in the in-memory store moneta is using so ruby's GC is unable to free those objects.

My in-memory store attempts to iterate over the internal hash every so often and delete expired values. This would only happen on lookups whenever the compaction window has passed.

Another benefit since the data only lives in memory is we don't need to serialize data which saves us quite a bit of cpu.

This is the current results of the benchmark I added, the circuit box memory store retained objects should grow and then shrink after a compaction happens.

```
Starting object use benchmark for circuitbox_memory_store
Initial object allocations: Strings: 15200, Arrays: 5393, Objects: 744, Hashes: 281
Object report #1: Strings: 15231, Arrays: 5393, Objects: 753, Hashes: 281
Object report #2: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #3: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #4: Strings: 15226, Arrays: 5393, Objects: 748, Hashes: 281
Object report #5: Strings: 15231, Arrays: 5393, Objects: 753, Hashes: 281
Object report #6: Strings: 15236, Arrays: 5393, Objects: 758, Hashes: 281
Object report #7: Strings: 15241, Arrays: 5393, Objects: 763, Hashes: 281
Object report #8: Strings: 15226, Arrays: 5393, Objects: 748, Hashes: 281
Object report #9: Strings: 15231, Arrays: 5393, Objects: 753, Hashes: 281
Object report #10: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #11: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #12: Strings: 15227, Arrays: 5393, Objects: 749, Hashes: 281
Object report #13: Strings: 15232, Arrays: 5393, Objects: 754, Hashes: 281
Object report #14: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #15: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #16: Strings: 15226, Arrays: 5393, Objects: 748, Hashes: 281
Object report #17: Strings: 15231, Arrays: 5393, Objects: 753, Hashes: 281
Object report #18: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #19: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #20: Strings: 15227, Arrays: 5393, Objects: 749, Hashes: 281
Object report #21: Strings: 15232, Arrays: 5393, Objects: 754, Hashes: 281
Object report #22: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #23: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #24: Strings: 15227, Arrays: 5393, Objects: 749, Hashes: 281
Object report #25: Strings: 15232, Arrays: 5393, Objects: 754, Hashes: 281
Object report #26: Strings: 15238, Arrays: 5393, Objects: 760, Hashes: 281
Object report #27: Strings: 15243, Arrays: 5393, Objects: 765, Hashes: 281
Object report #28: Strings: 15227, Arrays: 5393, Objects: 749, Hashes: 281
Object report #29: Strings: 15232, Arrays: 5393, Objects: 754, Hashes: 281
Object report #30: Strings: 15237, Arrays: 5393, Objects: 759, Hashes: 281
Object report #31: Strings: 15242, Arrays: 5393, Objects: 764, Hashes: 281
Object report #32: Strings: 15227, Arrays: 5393, Objects: 749, Hashes: 281
Object report #33: Strings: 15233, Arrays: 5393, Objects: 755, Hashes: 281
Final object allocations for circuitbox_memory_store: Strings: 15233, Arrays: 5393, Objects: 756, Hashes: 281
Starting object use benchmark for moneta_memory_store
Initial object allocations: Strings: 15234, Arrays: 5393, Objects: 756, Hashes: 281
Object report #1: Strings: 15259, Arrays: 5399, Objects: 755, Hashes: 282
Object report #2: Strings: 15269, Arrays: 5399, Objects: 755, Hashes: 282
Object report #3: Strings: 15279, Arrays: 5399, Objects: 755, Hashes: 282
Object report #4: Strings: 15289, Arrays: 5399, Objects: 755, Hashes: 282
Object report #5: Strings: 15299, Arrays: 5399, Objects: 755, Hashes: 282
Object report #6: Strings: 15309, Arrays: 5399, Objects: 755, Hashes: 282
Object report #7: Strings: 15319, Arrays: 5399, Objects: 755, Hashes: 282
Object report #8: Strings: 15329, Arrays: 5399, Objects: 755, Hashes: 282
Object report #9: Strings: 15341, Arrays: 5399, Objects: 755, Hashes: 282
Object report #10: Strings: 15351, Arrays: 5399, Objects: 755, Hashes: 282
Object report #11: Strings: 15361, Arrays: 5399, Objects: 755, Hashes: 282
Object report #12: Strings: 15371, Arrays: 5399, Objects: 755, Hashes: 282
Object report #13: Strings: 15381, Arrays: 5399, Objects: 755, Hashes: 282
Object report #14: Strings: 15391, Arrays: 5399, Objects: 755, Hashes: 282
Object report #15: Strings: 15401, Arrays: 5399, Objects: 755, Hashes: 282
Object report #16: Strings: 15411, Arrays: 5399, Objects: 755, Hashes: 282
Object report #17: Strings: 15423, Arrays: 5399, Objects: 755, Hashes: 282
Object report #18: Strings: 15433, Arrays: 5399, Objects: 755, Hashes: 282
Object report #19: Strings: 15443, Arrays: 5399, Objects: 755, Hashes: 282
Object report #20: Strings: 15453, Arrays: 5399, Objects: 755, Hashes: 282
Object report #21: Strings: 15463, Arrays: 5399, Objects: 755, Hashes: 282
Object report #22: Strings: 15473, Arrays: 5399, Objects: 755, Hashes: 282
Object report #23: Strings: 15483, Arrays: 5399, Objects: 755, Hashes: 282
Object report #24: Strings: 15495, Arrays: 5399, Objects: 755, Hashes: 282
Object report #25: Strings: 15505, Arrays: 5399, Objects: 755, Hashes: 282
Object report #26: Strings: 15515, Arrays: 5399, Objects: 755, Hashes: 282
Object report #27: Strings: 15525, Arrays: 5399, Objects: 755, Hashes: 282
Object report #28: Strings: 15535, Arrays: 5399, Objects: 755, Hashes: 282
Object report #29: Strings: 15545, Arrays: 5399, Objects: 755, Hashes: 282
Object report #30: Strings: 15555, Arrays: 5399, Objects: 755, Hashes: 282
Object report #31: Strings: 15567, Arrays: 5400, Objects: 755, Hashes: 282
Object report #32: Strings: 15577, Arrays: 5399, Objects: 755, Hashes: 282
Object report #33: Strings: 15587, Arrays: 5399, Objects: 755, Hashes: 282
Final object allocations for moneta_memory_store: Strings: 15588, Arrays: 5399, Objects: 755, Hashes: 282```