### PR TITLE
Fix circuit needing an additional run to calculate error rates

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -126,7 +126,7 @@ class Circuitbox
     end
 
     def passed_volume_threshold?(failures, successes)
-      failures + successes > option_value(:volume_threshold)
+      failures + successes >= option_value(:volume_threshold)
     end
 
     def passed_rate_threshold?(rate)

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -34,7 +34,7 @@ class CircuitBreakerTest < Minitest::Test
           raise Timeout::Error
         end
       end
-      assert_equal 6, run_counter, 'the circuit did not open after 6 failures (5 failures + 10%)'
+      assert_equal 5, run_counter, 'the circuit did not open after 5 failures'
     end
 
     def test_keep_circuit_closed_on_success
@@ -179,7 +179,7 @@ class CircuitBreakerTest < Minitest::Test
                                                 sleep_window: 2,
                                                 time_window: 2,
                                                 volume_threshold: 5,
-                                                error_threshold: 5,
+                                                error_threshold: 50,
                                                 exceptions: [Timeout::Error])
     end
 
@@ -189,6 +189,7 @@ class CircuitBreakerTest < Minitest::Test
 
       Timecop.freeze(current_time) do
         open_circuit!
+        # should_open? calculation happens when run is called here
         @circuit.run { run_count += 1 }
       end
 
@@ -206,7 +207,7 @@ class CircuitBreakerTest < Minitest::Test
     end
 
     def open_circuit!
-      (@circuit.option_value(:error_threshold) + 1).times { @circuit.run { raise Timeout::Error } }
+      @circuit.option_value(:volume_threshold).times { @circuit.run { raise Timeout::Error } }
     end
   end
 

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -29,7 +29,7 @@ class Circuitbox
     end
 
     def test_circuit_does_not_open_for_below_threshhold_failed_requests
-      5.times { connection.get(failure_url) }
+      4.times { connection.get(failure_url) }
       assert_equal connection.get(success_url).status, 200
     end
 


### PR DESCRIPTION
Change passed_volume_threshold? to return true when successes + failures is at or greater than the volume_threshold.

Currently the success + failures needs to be greater which means the circuit runs one more time after the volume threshold would be met in order to start calculating error rates.

I put together a small test to demonstrate the problem. Since every run of the circuit results in a failure I would expect that the 6th time the circuit is run the circuit opens and the block is not run. Against the latest changes in master the block is run 6 times and it's the 7th call to run that opens the circuit (the check to see if the circuit should open happens when run is called but before the block runs). In this pr the block runs 5 times and on the 6th call to run the circuit opens and the block is not run.

```ruby
require 'circuitbox'
require 'logger'

l = Logger.new(STDOUT)
l.level = Logger::WARN

c = Circuitbox::CircuitBreaker.new('test', time_window: 10, sleep_window: 10, volume_threshold: 5, logger: l, exceptions: [StandardError])

times_ran = 0

10.times do
  c.run do
    times_ran += 1
    raise StandardError
  end
end

puts "Total Times the circuit ran: #{times_ran}"
```

Running against SHA 3a1d5f78e0830e7307274d3ea3b096cabe8d1b4d (current master)
```
bundle exec ruby volume_threshold.rb
Total Times the circuit ran: 6
```

Running against this PR
```
bundle exec ruby volume_threshold.rb
Total Times the circuit ran: 5
```