### PR TITLE
Change when close messages are sent and how half open is cleared

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -56,7 +56,6 @@ class Circuitbox
       currently_open = open_flag?
       if currently_open || should_open?
         open! unless currently_open
-        logger.debug(circuit_open_message)
         skipped!
         raise Circuitbox::OpenCircuitError.new(service)
       else
@@ -66,11 +65,9 @@ class Circuitbox
           response = execution_timer.time(service, notifier, 'execution_time') do
             yield
           end
-          logger.debug(circuit_success_message)
           success!
           close! if half_open?
         rescue *exceptions => exception
-          logger.debug(circuit_failure_message)
           failure!
           open! if half_open?
           raise Circuitbox::ServiceFailureError.new(service, exception)
@@ -173,14 +170,17 @@ class Circuitbox
 
     def success!
       notify_and_increment_event('success')
+      logger.debug(circuit_success_message)
     end
 
     def failure!
       notify_and_increment_event('failure')
+      logger.debug(circuit_failure_message)
     end
 
     def skipped!
       notify_event('skipped')
+      logger.debug(circuit_skipped_message)
     end
 
     # Send event notification to notifier

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -55,22 +55,22 @@ class Circuitbox
     def run!
       currently_open = open_flag?
       if currently_open || should_open?
-        logger.debug(circuit_open_message)
         open! unless currently_open
+        logger.debug(circuit_open_message)
         skipped!
         raise Circuitbox::OpenCircuitError.new(service)
       else
-        logger.debug(circuit_closed_querying_message)
+        logger.debug(circuit_running_message)
 
         begin
           response = execution_timer.time(service, notifier, 'execution_time') do
             yield
           end
-          logger.debug(circuit_closed_query_success_message)
+          logger.debug(circuit_success_message)
           success!
           close! if half_open?
         rescue *exceptions => exception
-          logger.debug(circuit_closed_failure_message)
+          logger.debug(circuit_failure_message)
           failure!
           open! if half_open?
           raise Circuitbox::ServiceFailureError.new(service, exception)
@@ -145,7 +145,7 @@ class Circuitbox
       # Running event and logger outside of the synchronize block to allow other threads
       # that may be waiting to become unblocked
       notify_event('open')
-      logger.debug(circuit_opening_message)
+      logger.debug(circuit_opened_message)
     end
 
     def close!
@@ -156,6 +156,7 @@ class Circuitbox
       # Running event outside of the synchronize block to allow other threads
       # that may be waiting to become unblocked
       notify_event('close')
+      logger.debug(circuit_closed_message)
     end
 
     def half_open!

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -147,6 +147,9 @@ class Circuitbox
 
     def close!
       @state_change_mutex.synchronize do
+        # If the circuit is not open, the half_open key will be deleted from the store
+        # if half_open exists the deleted value is returned and allows us to continue
+        # if half_open doesn't exist nil is returned, causing us to return early
         return unless !open_flag? && circuit_store.delete(storage_key('half_open'))
       end
 

--- a/lib/circuitbox/circuit_breaker/logger_messages.rb
+++ b/lib/circuitbox/circuit_breaker/logger_messages.rb
@@ -4,23 +4,27 @@ class Circuitbox
   class CircuitBreaker
     module LoggerMessages
       def circuit_open_message
-        @circuit_open_message ||= "[CIRCUIT] open: skipping #{service}"
+        @circuit_open_message ||= "[CIRCUIT] #{service}: skipping"
       end
 
-      def circuit_closed_querying_message
-        @circuit_closed_querying_message ||= "[CIRCUIT] closed: querying #{service}"
+      def circuit_running_message
+        @circuit_running_message ||= "[CIRCUIT] #{service}: running"
       end
 
-      def circuit_closed_query_success_message
-        @circuit_closed_query_success_message ||= "[CIRCUIT] closed: #{service} query success"
+      def circuit_success_message
+        @circuit_success_message ||= "[CIRCUIT] #{service}: success"
       end
 
-      def circuit_closed_failure_message
-        @closed_failure_message ||= "[CIRCUIT] closed: detected #{service} failure"
+      def circuit_failure_message
+        @circuit_failure_message ||= "[CIRCUIT] #{service}: failure"
       end
 
-      def circuit_opening_message
-        @opening_message ||= "[CIRCUIT] opening #{service} circuit"
+      def circuit_opened_message
+        @circuit_opened_message ||= "[CIRCUIT] #{service}: opened"
+      end
+
+      def circuit_closed_message
+        @circuit_closed_message ||= "[CIRCUIT] #{service}: closed"
       end
     end
   end

--- a/lib/circuitbox/circuit_breaker/logger_messages.rb
+++ b/lib/circuitbox/circuit_breaker/logger_messages.rb
@@ -3,8 +3,8 @@
 class Circuitbox
   class CircuitBreaker
     module LoggerMessages
-      def circuit_open_message
-        @circuit_open_message ||= "[CIRCUIT] #{service}: skipping"
+      def circuit_skipped_message
+        @circuit_open_message ||= "[CIRCUIT] #{service}: skipped"
       end
 
       def circuit_running_message


### PR DESCRIPTION
This pr changes/fixes two big things and has a few little changes.

## Changes

1. When a circuit was in the half_open state it would send a notification that the circuit was closed before running the block. This became apparent if the block that was run in the half open state was not successful. In logs this would appear like the circuit was closed and then opened after one failure. What should happen is the circuit doesn't go into the closed state until the block is successful. I wrote a simple way to visualize the issue.

```ruby
require 'circuitbox'
require 'logger'
require 'circuitbox/memory_store'

class Bench
  class << self
    def run
      l = Logger.new(STDOUT)
      l.level = Logger::DEBUG
      l.formatter = proc { |severity, _, _, msg| "#{severity}: #{msg}\n" }

      c = Circuitbox::CircuitBreaker.new('test', time_window: 3, sleep_window: 3, volume_threshold: 5, logger: l, exceptions: [StandardError], cache: Circuitbox::MemoryStore.new)

      6.times do
        c.run { raise StandardError }
      end

      sleep 4

      c.run { raise StandardError }
    end
  end
end

Bench.run
```
When run against c848c46 the log output is
```
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] open: skipping test
DEBUG: [CIRCUIT] opening test circuit
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] opening test circuit
```
With the changes in this pr the output does not show the circuit being in the closed state if the block was not successful. Note that the logger messages are more condensed, I'll talk about that later.
```
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: opened
DEBUG: [CIRCUIT] test: skipped
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: opened
```

2. When running the circuit across multiple threads the half_open state can be cleared while the circuit is open. For simplicity, say the circuit needs 1 more unsuccessful run to go over the error threshold and open on the next attempt. Thread 1 runs a block on the circuit and is taking some time to complete. Thread 2 runs a block on the circuit and is not successful (this pushes the circuit over the error threshold). Thread 3 attempts to run a block causing the circuit to open which skips running the block. Thread 1 completes successfully and the half open state is cleared. Once the circuit open "expires" the circuit goes back to the closed state without testing the service. I wrote a way to visualize this (only needing 2 threads)

```ruby
require 'circuitbox'
require 'logger'
require 'circuitbox/memory_store'

class Bench
  class << self
    def run
      l = Logger.new(STDOUT)
      l.level = Logger::DEBUG
      l.formatter = proc { |severity, _, _, msg| "#{severity}: #{msg}\n" }

      c = Circuitbox::CircuitBreaker.new('test', time_window: 3, sleep_window: 3, volume_threshold: 5, logger: l, exceptions: [StandardError], cache: Circuitbox::MemoryStore.new)

      Thread.new do
        c.run { sleep 1 }
      end

      6.times do
        c.run { raise StandardError }
      end

      sleep 4

      2.times do
        c.run { raise StandardError }
      end
    end
  end
end

Bench.run
```
When run against c848c46 the log output is
```
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] open: skipping test
DEBUG: [CIRCUIT] opening test circuit
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: test query success
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
DEBUG: [CIRCUIT] closed: querying test
DEBUG: [CIRCUIT] closed: detected test failure
```
With the changes in this pr the half_open state is not cleared when the circuit is currently open. This is achieved by taking a lock when changing the state of the circuit (open! and closed!). The need for a lock comes from having to make multiple trips to the cache in order to change the state of the circuit. I've attempted to keep the locks as small as possible by moving events and logging outside of the lock. The log output now shows the circuit going back to the open state when the half_open request fails.
```
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: opened
DEBUG: [CIRCUIT] test: skipped
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: success
DEBUG: [CIRCUIT] test: running
DEBUG: [CIRCUIT] test: failure
DEBUG: [CIRCUIT] test: opened
DEBUG: [CIRCUIT] test: skipped
```

Something to note (circuitbox has been this way for as long as I remember) when in the half_open state more than one thread can be running a block in the circuit. The first thread that finishes running its block and takes the lock dictates what the state of the circuit changes to (open or close).

3. Simplified the logger messages so they are easier to read. Previously the circuit name was at random positions in the messages, now it is always right after ```[CIRCUIT]```. I've also shortened the messages and renamed them to what seems to make the most sense to me.

## Benchmarks
It might seem like circuitbox is going to get slower because of the added mutex but that is only used on state changes. I was able to not have to try and delete the ```half_open`` key for every success.

This is what I'm running to benchmark the changes in the case the circuit stays closed

```ruby
require 'benchmark/ips'
require 'circuitbox'
require 'logger'
require 'circuitbox/memory_store'

l = Logger.new(STDOUT)
l.level = Logger::WARN
c = Circuitbox::CircuitBreaker.new('test', time_window: 60, sleep_window: 60, volume_threshold: 5, logger: l, exceptions: [StandardError], cache: Circuitbox::MemoryStore.new)

Benchmark.ips do |x|
  x.iterations = 3

  x.report('circuitbox') { c.run! { } }

  x.report('circuitbox-pr') { c.run! { } }

  x.hold! 'run_bench_data'

  x.compare!
end
```
The results
```
Warming up --------------------------------------
          circuitbox     8.338k i/100ms
          circuitbox     8.461k i/100ms
          circuitbox     8.315k i/100ms
Calculating -------------------------------------
          circuitbox     86.691k (± 4.3%) i/s -    440.695k in   5.093668s
          circuitbox     85.887k (± 4.9%) i/s -    432.380k in   5.046919s
          circuitbox     86.245k (± 4.3%) i/s -    432.380k in   5.023160s

Pausing here -- run Ruby again to measure the next benchmark...

Warming up --------------------------------------
       circuitbox-pr     8.380k i/100ms
       circuitbox-pr     8.681k i/100ms
       circuitbox-pr     8.230k i/100ms
Calculating -------------------------------------
       circuitbox-pr     87.589k (± 5.4%) i/s -    444.420k in   5.089115s
       circuitbox-pr     87.998k (± 5.3%) i/s -    444.420k in   5.064894s
       circuitbox-pr     88.599k (± 4.8%) i/s -    444.420k in   5.028124s

Comparison:
       circuitbox-pr:    88599.0 i/s
          circuitbox:    86245.3 i/s - same-ish: difference falls within error
```

The two methods that received the most changes are ```open!``` and ```close!```. The difficulty with benchmarking these methods is the new version has guards so they appear significantly faster when benchmarking them without resetting the state. The new changes should be slower because they need to take a lock (when using threads they can be blocked by the lock too).