### PR TITLE
Change when circuits open

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,7 @@ end
 
 `payload[:gauge]` can be:
 
-- `failure_count`
-- `success_count`
-- `error_rate`
-- `execution_time` # execution time will only be notified when circuit is closed and block is successfully executed without timeout or errors.
+- `execution_time` # execution time will only be notified when circuit is closed and block is successfully executed.
 
 **warnings:**
 in case of misconfiguration, circuitbox will fire a circuitbox_warning

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class ExampleServiceClient
       # length of interval (in seconds) over which it calculates the error rate
       time_window:      60,
 
-      # number of requests within `time_window` seconds before it calculates error rates
+      # number of requests within `time_window` seconds before it calculates error rates (checked on failures)
       volume_threshold: 10,
 
       # the store you want to use to save the circuit state so it can be
@@ -84,7 +84,7 @@ class ExampleServiceClient
       # this overrides what is set in the global configuration
       cache: Moneta.new(:Memory),
 
-      # exceeding this rate will open the circuit
+      # exceeding this rate will open the circuit (checked on failures)
       error_threshold:  50,
 
       # Logger to use

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -118,8 +118,6 @@ class Circuitbox
       successes = success_count
       rate = error_rate(failures, successes)
 
-      log_metrics(rate, failures, successes)
-
       passed_volume_threshold?(failures, successes) && passed_rate_threshold?(rate)
     end
 
@@ -195,12 +193,6 @@ class Circuitbox
     def notify_and_increment_event(event)
       notify_event(event)
       circuit_store.increment(stat_storage_key(event), 1, expires: (option_value(:time_window) * 2))
-    end
-
-    def log_metrics(error_rate, failures, successes)
-      notifier.metric_gauge(service, 'error_rate', error_rate)
-      notifier.metric_gauge(service, 'failure_count', failures)
-      notifier.metric_gauge(service, 'success_count', successes)
     end
 
     def check_sleep_window

--- a/lib/circuitbox/timer/monotonic.rb
+++ b/lib/circuitbox/timer/monotonic.rb
@@ -1,7 +1,7 @@
 class Circuitbox
   class Timer
     class Monotonic
-      def initialize(time_unit = :milliseconds)
+      def initialize(time_unit = :millisecond)
         @time_unit = time_unit
       end
 

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -134,7 +134,7 @@ class CircuitBreakerTest < Minitest::Test
     def setup
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                 exceptions: [Timeout::Error],
-                                                cache: ExpiringCache.new('circuits:yammer:asleep', true))
+                                                cache: ExpiringCache.new('circuits:yammer:open', true))
     end
 
     def test_key_expiration_closes_circuit

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -510,33 +510,6 @@ class CircuitBreakerTest < Minitest::Test
       assert_equal false, notifier.notified?, 'no notification sent'
     end
 
-    def test_notifies_on_success_rate_calculation
-      notifier = gimme_notifier(metric: 'error_rate', metric_value: 0.0)
-      circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                               notifier: notifier,
-                                               exceptions: [Timeout::Error])
-      10.times { circuit.run { 'success' } }
-      assert notifier.notified?, 'no notification sent'
-    end
-
-    def test_notifies_on_error_rate_calculation
-      notifier = gimme_notifier(metric: 'failure_count', metric_value: 1)
-      circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                               notifier: notifier,
-                                               exceptions: [Timeout::Error])
-      10.times { circuit.run { raise Timeout::Error } }
-      assert notifier.notified?, 'no notification sent'
-    end
-
-    def test_success_count_on_error_rate_calculation
-      notifier = gimme_notifier(metric: 'success_count', metric_value: 6)
-      circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                               notifier: notifier,
-                                               exceptions: [Timeout::Error])
-      10.times { circuit.run { 'success' } }
-      assert notifier.notified?, 'no notification sent'
-    end
-
     def test_not_notify_circuit_execution_time_on_null_timer
       notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
       timer = Circuitbox::Timer::Null.new


### PR DESCRIPTION
Currently circuitbox circuits open on the next time the circuit is run. This can lead to an edge case where the circuit would have passed the volume and error thresholds at the very end of a time_window but stay closed if the next run is after the time window resets. Also the sleep time starts from the time the next time the circuit is run, not from the failure that caused the circuit to pass the volume and error thresholds.

This pr moves the open calculation to the failure part of a circuit and has a few changes I think are worth discussing.

1. Circuitbox won't emit an error rate / success count / failure count anymore. It still emit's success and failures, which allows error rate to be outside of Circuitbox using those metrics.

2. Closed -> Open is only calculated on failure. There is an edge case with this approach where failures followed by successes could keep the circuit closed. If the volume threshold was set to 10, error percentage was 50%, we had 9 failures in the beginning of a time window, and the rest of the runs were successful the circuit would never open. If we had 9 failures followed by 2 successes and then 1 failure the circuit would open after this failure. Currently this would look like 9 failures + 1 success and the next attempt would open the circuit.

I've also fixed a potential problem that can happen when moving from half_open to open.