### PR TITLE
Simplify run methods

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -66,6 +66,9 @@ class Circuitbox
 
           success!
         rescue *exceptions => exception
+          # Other stores could raise an exception that circuitbox is asked to watch.
+          # setting to nil keeps the same behavior as the previous defination of run.
+          response = nil
           failure!
           raise Circuitbox::ServiceFailureError.new(service, exception) if circuitbox_exceptions
         end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -52,10 +52,10 @@ class Circuitbox
       value.is_a?(Proc) ? value.call : value
     end
 
-    def run!
+    def run(circuitbox_exceptions: true)
       if open_flag?
         skipped!
-        raise Circuitbox::OpenCircuitError.new(service)
+        raise Circuitbox::OpenCircuitError.new(service) if circuitbox_exceptions
       else
         logger.debug(circuit_running_message)
 
@@ -67,17 +67,11 @@ class Circuitbox
           success!
         rescue *exceptions => exception
           failure!
-          raise Circuitbox::ServiceFailureError.new(service, exception)
+          raise Circuitbox::ServiceFailureError.new(service, exception) if circuitbox_exceptions
         end
       end
 
       response
-    end
-
-    def run
-      run! { yield }
-    rescue Circuitbox::Error
-      nil
     end
 
     def open?

--- a/lib/circuitbox/excon_middleware.rb
+++ b/lib/circuitbox/excon_middleware.rb
@@ -32,7 +32,7 @@ class Circuitbox
     end
 
     def error_call(datum)
-      circuit(datum).run! do
+      circuit(datum).run do
         raise RequestFailed
       end
     rescue Circuitbox::Error => exception
@@ -40,13 +40,13 @@ class Circuitbox
     end
 
     def request_call(datum)
-      circuit(datum).run! do
+      circuit(datum).run do
         @stack.request_call(datum)
       end
     end
 
     def response_call(datum)
-      circuit(datum).run! do
+      circuit(datum).run do
         raise RequestFailed if open_circuit?(datum[:response])
       end
       @stack.response_call(datum)

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -51,7 +51,7 @@ class Circuitbox
 
     def call(request_env)
       service_response = nil
-      circuit(request_env).run! do
+      circuit(request_env).run do
         @app.call(request_env).on_complete do |env|
           service_response = Faraday::Response.new(env)
           raise RequestFailed if open_circuit?(service_response)

--- a/test/excon_middleware_test.rb
+++ b/test/excon_middleware_test.rb
@@ -28,7 +28,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com' }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       default_value_generator = ->(_, _) { :sential }
       middleware = ExconMiddleware.new(app,
                                        circuitbox: circuitbox,
@@ -40,7 +40,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com' }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox, default_value: :sential)
       assert_equal :sential, middleware.error_call(env)
     end
@@ -97,7 +97,7 @@ class Circuitbox
       stub_circuitbox
       env = { host: 'yammer.com', circuit_breaker_default_value: :sential }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
       assert_equal middleware.error_call(env), :sential
     end
@@ -105,7 +105,7 @@ class Circuitbox
     def test_return_null_response_for_open_circuit
       stub_circuitbox
       env = { host: 'yammer.com' }
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       mw = ExconMiddleware.new(app, circuitbox: circuitbox)
       response = mw.error_call(env)

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -41,7 +41,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       default_value_generator = ->(_, _) { :sential }
@@ -53,7 +53,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-      give(circuit).run! { raise Circuitbox::Error, 'error text' }
+      give(circuit).run { raise Circuitbox::Error, 'error text' }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       default_value_generator = ->(_, error) { error.message }
@@ -65,7 +65,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       middleware = FaradayMiddleware.new(app, default_value: :sential)
@@ -150,7 +150,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/'), circuit_breaker_default_value: :sential }
 
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       middleware = FaradayMiddleware.new(app)
@@ -161,8 +161,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-
-      give(circuit).run! { :sential }
+      give(circuit).run { :sential }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       middleware = FaradayMiddleware.new(app)
@@ -173,7 +172,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-      give(circuit).run! { raise Circuitbox::Error }
+      give(circuit).run { raise Circuitbox::Error }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       response = FaradayMiddleware.new(app).call(env)


### PR DESCRIPTION
Circuitbox's ```run``` method rescues exceptions to return nil. Raising / rescuing these exceptions to return nil is pretty expensive. By switching run to take the keyword arg ```circuitbox_exceptions``` we don't need to raise exceptions just to return nil on failure.

This is a breaking change, but this is going in with a major version bump.