### PR TITLE
Faraday middleware cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,6 @@ end
 By default the Faraday middleware returns a `503` response when the circuit is
 open, but this as many other things can be configured via middleware options
 
-* `exceptions` pass a list of exceptions for the Circuitbreaker to catch,
-  defaults to Faraday::Error::TimeoutError and Request failures
-
-```ruby
-c.use Circuitbox::FaradayMiddleware, exceptions: [Faraday::Error::TimeoutError]
-```
-
 * `default_value` value to return for open circuits, defaults to 503 response
   wrapping the original response given by the service and stored as
   `original_response` property of the returned 503, this can be overwritten
@@ -306,7 +299,8 @@ c.use Circuitbox::FaradayMiddleware, identifier: "service_name_circuit"
 ```
 
 * `circuit_breaker_options` options to initialize the circuit with defaults to
-  `{ volume_threshold: 10, exceptions: Circuitbox::FaradayMiddleware::DEFAULT_EXCEPTIONS }`
+  `{ exceptions: Circuitbox::FaradayMiddleware::DEFAULT_EXCEPTIONS }`.
+  Accepts same options as Circuitbox:CircuitBreaker#new
 
 ```ruby
 c.use Circuitbox::FaradayMiddleware, circuit_breaker_options: {}

--- a/README.md
+++ b/README.md
@@ -293,9 +293,7 @@ c.use Circuitbox::FaradayMiddleware, exceptions: [Faraday::Error::TimeoutError]
   * a `lambda` which is passed the `original_response` and `original_error`.
     `original_response` will be populated if Faraday returns an error response,
     `original_error` will be populated if an error was thrown before Faraday
-    returned a response.  (It will also accept a lambda with arity 1 that is
-    only passed `original_response`.  This use is deprecated and will be removed
-    in the next major version.)
+    returned a response.
 
 ```ruby
 c.use Circuitbox::FaradayMiddleware, default_value: lambda { |response, error| ... }

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -88,15 +88,7 @@ class Circuitbox
     end
 
     def circuit_open_value(env, service_response, exception)
-      env[:circuit_breaker_default_value] || call_default_lambda(service_response, exception)
-    end
-
-    def call_default_lambda(service_response, exception)
-      if default_value.arity == 2
-        default_value.call(service_response, exception)
-      else
-        default_value.call(service_response)
-      end
+      env[:circuit_breaker_default_value] || default_value.call(service_response, exception)
     end
 
     def circuit(env)

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -80,17 +80,13 @@ class Circuitbox
       opts[:open_circuit].call(response)
     end
 
-    def circuitbox
-      @circuitbox ||= opts.fetch(:circuitbox, Circuitbox)
-    end
-
     def circuit_open_value(env, service_response, exception)
       env[:circuit_breaker_default_value] || call_default_value(service_response, exception)
     end
 
     def circuit(env)
       id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
-      circuitbox.circuit(id, circuit_breaker_options)
+      Circuitbox.circuit(id, circuit_breaker_options)
     end
   end
 end

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -7,8 +7,8 @@ class Circuitbox
 
     DEFAULT_EXCEPTIONS = [
       Faraday::Error::TimeoutError,
-      RequestFailed,
-    ]
+      RequestFailed
+    ].freeze
 
     class NullResponse < Faraday::Response
       attr_reader :original_response, :original_exception
@@ -90,7 +90,7 @@ class Circuitbox
 
     def circuit(env)
       id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
-      circuitbox.circuit id, circuit_breaker_options
+      circuitbox.circuit(id, circuit_breaker_options)
     end
   end
 end

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -65,9 +65,7 @@ class Circuitbox
     def circuit_breaker_options
       @circuit_breaker_options ||= begin
         options = opts.fetch(:circuit_breaker_options, {})
-        options.merge!(
-          exceptions: opts.fetch(:exceptions, DEFAULT_EXCEPTIONS)
-        )
+        { exceptions: DEFAULT_EXCEPTIONS }.merge!(options)
       end
     end
 

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -26,7 +26,7 @@ class Circuitbox
         # response.status:
         # nil -> connection could not be established, or failed very hard
         # 5xx -> non recoverable server error, oposed to 4xx which are client errors
-        response.status.nil? || (500 <= response.status && response.status <= 599)
+        response.status.nil? || (response.status >= 500 && response.status <= 599)
       end,
       default_value: ->(service_response, exception) { NullResponse.new(service_response, exception) }
     }

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -29,7 +29,7 @@ class Circuitbox
       env = { url: URI('http://yammer.com/') }
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run! { raise Circuitbox::Error }
-      default_value_generator = lambda { |response| :sential }
+      default_value_generator = ->(_, _) { :sential }
       middleware = FaradayMiddleware.new(app,
                                          circuitbox: circuitbox,
                                          default_value: default_value_generator)

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -61,8 +61,10 @@ class Circuitbox
 
     def test_default_exceptions
       middleware = FaradayMiddleware.new(app)
-      assert_includes middleware.exceptions, Faraday::Error::TimeoutError
-      assert_includes middleware.exceptions, FaradayMiddleware::RequestFailed
+      circuit_breaker_options = middleware.opts[:circuit_breaker_options]
+
+      assert_includes circuit_breaker_options[:exceptions], Faraday::Error::TimeoutError
+      assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
     end
 
     def test_overridde_success_response
@@ -112,7 +114,9 @@ class Circuitbox
 
     def test_overwrite_exceptions
       middleware = FaradayMiddleware.new(app, circuit_breaker_options: { exceptions: [SentialException] })
-      assert_includes middleware.exceptions, SentialException
+      circuit_breaker_options = middleware.opts[:circuit_breaker_options]
+
+      assert_includes circuit_breaker_options[:exceptions], SentialException
     end
 
     def test_pass_circuit_breaker_options

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -15,13 +15,26 @@ class Circuitbox
     end
 
     def test_default_identifier
+      middleware = FaradayMiddleware.new(app)
       env = { url: URI('http://yammer.com/') }
-      assert_equal 'yammer.com', FaradayMiddleware.new(app).identifier.call(env)
+
+      assert_equal 'yammer.com', middleware.opts[:identifier].call(env)
+    end
+
+    def test_default_identifier_no_host
+      middleware = FaradayMiddleware.new(app)
+      uri = gimme
+      give(uri).host { nil }
+      give(uri).to_s { 'yam'}
+      env = { url: uri }
+
+      assert_equal 'yam', middleware.opts[:identifier].call(env)
     end
 
     def test_overwrite_identifier
       middleware = FaradayMiddleware.new(app, identifier: 'sential')
-      assert_equal middleware.identifier, 'sential'
+
+      assert_equal middleware.opts[:identifier], 'sential'
     end
 
     def test_overwrite_default_value_generator_lambda

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -111,7 +111,7 @@ class Circuitbox
     end
 
     def test_overwrite_exceptions
-      middleware = FaradayMiddleware.new(app, exceptions: [SentialException])
+      middleware = FaradayMiddleware.new(app, circuit_breaker_options: { exceptions: [SentialException] })
       assert_includes middleware.exceptions, SentialException
     end
 


### PR DESCRIPTION
There are a handful of changes here so lets jump right in

1. The ```default_value``` lambda could accept one argument, this functionality was deprecated and now it has been removed. When ```default_value``` is not a lambda remove the need to wrap it in a lambda.

2. Remove the undocumented option ```:circuitbox```. This required updating quite a few tests.

3. Move ```default_value``` and ```identifier``` to the ```DEFAULT_OPTIONS``` constant (this was also renamed from ```DEFAULT_CIRCUITBOX_OPTIONS```). This allows the defaults to be reused across instances of the middleware.

4. The middleware's ```:exceptions``` argument was merged  into ```:circuit_breaker_options```. If one was specified in ```:circuit_breaker_options``` it would get overridden. Since exceptions are only used by the circuit breaker options (an only really used on the initial creation of the circuit) the only way to specify them now is in ```:circuit_breaker_options```. The documentation in the readme has been updated for this.