### PR TITLE
Only call exception.backtrace once for service failure errors

### DIFF
--- a/lib/circuitbox/errors/error.rb
+++ b/lib/circuitbox/errors/error.rb
@@ -1,4 +1,3 @@
 class Circuitbox
-  class Error < StandardError
-  end
+  class Error < StandardError; end
 end

--- a/lib/circuitbox/errors/open_circuit_error.rb
+++ b/lib/circuitbox/errors/open_circuit_error.rb
@@ -5,6 +5,5 @@ class Circuitbox
     def initialize(service)
       @service = service
     end
-
   end
 end

--- a/lib/circuitbox/errors/service_failure_error.rb
+++ b/lib/circuitbox/errors/service_failure_error.rb
@@ -6,7 +6,8 @@ class Circuitbox
       @service = service
       @original = exception
       # we copy over the original exceptions backtrace if there is one
-      set_backtrace(exception.backtrace) unless exception.backtrace.empty?
+      backtrace = exception.backtrace
+      set_backtrace(backtrace) unless backtrace.empty?
     end
 
     def to_s


### PR DESCRIPTION
Benchmarks show a slight improvement by not calling exception.backtrace multiple times.