### PR TITLE
Change the name of circuit_open_message ivar to match the name of the method

### DIFF
--- a/lib/circuitbox/circuit_breaker/logger_messages.rb
+++ b/lib/circuitbox/circuit_breaker/logger_messages.rb
@@ -4,7 +4,7 @@ class Circuitbox
   class CircuitBreaker
     module LoggerMessages
       def circuit_skipped_message
-        @circuit_open_message ||= "[CIRCUIT] #{service}: skipped"
+        @circuit_skipped_message ||= "[CIRCUIT] #{service}: skipped"
       end
 
       def circuit_running_message


### PR DESCRIPTION
Forgot to update this when changing around the logger messages. Now the instance variable matches the method name.