### PR TITLE
Test under ruby 2.6 and stop testing under 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
+dist: xenial
 language: ruby
-sudo: false
 gemfile: ci/Gemfile
 env:
   - ACTIVE_SUPPORT=true
   - NO_ACTIVE_SUPPORT=true
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
   - ruby-head
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: ruby-head
 before_install:


### PR DESCRIPTION
Updates to Travis CI to test under ruby 2.6. Stop testing ruby 2.2.