### PR TITLE
Change default_circuit_store to the circuit box store

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ will need to be recreated to pick up the new defaults.
 ```ruby
   Circuitbox.configure do |config|
     config.default_circuit_store = Circuitbox::MemoryStore.new,
-    config.default_notifier = Notifier::Null.new,
+    config.default_notifier = Circuitbox::Notifier::Null.new,
     config.default_timer = Circuitbox::Timer::Simple.new,
     config.default_logger = Rails.logger
   end

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ will need to be recreated to pick up the new defaults.
 
 ```ruby
   Circuitbox.configure do |config|
-    config.default_circuit_store = Moneta.new(:memory, expires: true),
-    config.default_notifier = Notifier.new,
-    config.default_timer = Timer::Simple.new,
+    config.default_circuit_store = Circuitbox::MemoryStore.new,
+    config.default_notifier = Notifier::Null.new,
+    config.default_timer = Circuitbox::Timer::Simple.new,
     config.default_logger = Rails.logger
   end
 ```
@@ -82,7 +82,7 @@ class ExampleServiceClient
       # the store you want to use to save the circuit state so it can be
       # tracked, this needs to be Moneta compatible, and support increment
       # this overrides what is set in the global configuration
-      cache: Moneta.new(:Memory),
+      cache: Circuitbox::MemoryStore.new,
 
       # exceeding this rate will open the circuit (checked on failures)
       error_threshold:  50,
@@ -118,12 +118,14 @@ Circuitbox.circuit(:yammer, {
 ## Circuit Store (:cache)
 
 Holds all the relevant data to trip the circuit if a given number of requests
-fail in a specified period of time. The store is based on
-[Moneta](https://github.com/minad/moneta) so there are a lot of stores to choose
-from. There are some pre-requisits they need to satisfy so:
+fail in a specified period of time. Circuitbox also supports
+[Moneta](https://github.com/minad/moneta). As moneta is not a dependency of circuitbox
+it needs to be loaded prior to use. There are a lot of moneta stores to choose from but
+some pre-requisits need to be satisfied first:
 
-- Need to support increment, this is true for most but not all available stores.
-- Need to support concurrent access if you share them. For example sharing a
+- Needs to support increment, this is true for most but not all available stores.
+- Needs to support expiry.
+- Needs to support concurrent access if you share them. For example sharing a
   KyotoCabinet store across process fails because the store is single writer
   multiple readers, and all circuits sharing the store need to be able to write.
 
@@ -180,77 +182,6 @@ ActiveSupport::Notifications.subscribe('circuit_warning') do |name, start, finis
 end
 
 ```
-
-### Multi process Circuits
-
-`circuit_store` is backed by [Moneta](https://github.com/minad/moneta) which
-supports multiple backends. This can be configured by passing `cache:
-Moneta.new(:PStore, file: "myfile.store")` to use for example the built in
-PStore ruby library for persisted store, which can be shared cross process.
-
-Depending on your requirements different stores can make sense, see the
-benchmarks and [moneta
-feature](https://github.com/minad/moneta#backend-feature-matrix) matrix for
-details.
-
-```
-user     system      total        real
-memory:    1.440000   0.140000   1.580000 (  1.579244)
-lmdb:      4.330000   3.280000   7.610000 ( 13.086398)
-pstore:   23.680000   4.350000  28.030000 ( 28.094312)
-daybreak:  2.270000   0.450000   2.720000 (  2.626748)
-```
-
-You can run the benchmarks yourself by running `rake benchmark`.
-
-### Memory
-
-An in memory store, which is local to the process. This is not threadsafe so it
-is not useable with multithreaded webservers for example. It is always going to
-be the fastest option if no multi-process or thread is required, like in
-development on Webbrick.
-
-This is the default.
-
-```ruby
-Circuitbox.circuit :identifier, exceptions: [Net::ReadTimeout], cache: Moneta.new(:Memory)
-```
-
-### LMDB
-
-An persisted directory backed store, which is thread and multi process safe.
-depends on the `lmdb` gem. It is slower than Memory or Daybreak, but can be
-used in multi thread and multi process environments like like Puma.
-
-```ruby
-require "lmdb"
-Circuitbox.circuit :identifier, exceptions: [Net::ReadTimeout], cache: Moneta.new(:LMDB, dir: "./", db: "mydb")
-```
-
-### PStore
-
-An persisted file backed store, which comes with the ruby
-[stdlib](http://ruby-doc.org/stdlib-2.3.0/libdoc/pstore/rdoc/PStore.html). It
-has no external dependencies and works on every ruby implementation. Due to it
-being file backed it is multi process safe, good for development using Unicorn.
-
-```ruby
-Circuitbox.circuit :identifier, exceptions: [Net::ReadTimeout], cache: Moneta.new(:PStore, file: "db.pstore")
-```
-
-### Daybreak
-
-Persisted, file backed key value store in pure ruby. It is process safe and
-outperforms most other stores in circuitbox. This is recommended for production
-use with Unicorn. It depends on the `daybreak` gem.
-
-```ruby
-require "daybreak"
-Circuitbox.circuit :identifier, exceptions: [Net::ReadTimeout], cache: Moneta.new(:Daybreak, file: "db.daybreak", expires: true)
-```
-
-It is important for the store to have
-[expires](https://github.com/minad/moneta#backend-feature-matrix) support.
 
 ## Faraday
 

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'typhoeus', '~> 1.3'
-
-  spec.add_dependency 'moneta', '~> 1.0'
+  spec.add_development_dependency 'moneta', '~> 1.0'
 end

--- a/lib/circuitbox/configuration.rb
+++ b/lib/circuitbox/configuration.rb
@@ -1,4 +1,4 @@
-require 'moneta'
+require_relative 'memory_store'
 require_relative 'timer/simple'
 require_relative 'notifier/active_support'
 require_relative 'notifier/null'
@@ -17,7 +17,7 @@ class Circuitbox
     end
 
     def default_circuit_store
-      @default_circuit_store ||= Moneta.new(:Memory, expires: true, threadsafe: true)
+      @default_circuit_store ||= MemoryStore.new
     end
 
     def default_notifier

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'moneta'
 require 'circuitbox/timer/null'
 
 class CircuitBreakerTest < Minitest::Test

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'moneta'
 require 'circuitbox/faraday_middleware'
 
 class SentialException < StandardError; end

--- a/test/integration/faraday_middleware_test.rb
+++ b/test/integration/faraday_middleware_test.rb
@@ -1,4 +1,5 @@
 require "integration_helper"
+require 'moneta'
 require "typhoeus/adapters/faraday"
 
 class Circuitbox


### PR DESCRIPTION
Moneta is moved to a development dependency with this change. Those still wanting to use moneta will need to load the gem manually and then set the circuit store per circuit or globally through ```Circuitbox.configure```.