### PR TITLE
Fix Circuitbox.circuit to use previous run behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ class ExampleServiceClient
   end
 
   def http_get
-    circuit.run do
+    circuit.run(circuitbox_exceptions: false) do
       Zephyr.new("http://example.com").get(200, 1000, "/api/messages")
     end
   end
 end
 ```
 
-Using the `run!` method will throw an exception when the circuit is open or the underlying service fails.
+Using the `run` method will throw an exception when the circuit is open or the underlying service fails.
 
 ```ruby
   def http_get
-    circuit.run! do
+    circuit.run do
       Zephyr.new("http://example.com").get(200, 1000, "/api/messages")
     end
   end

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -21,7 +21,7 @@ class Circuitbox
 
       return circuit unless block_given?
 
-      circuit.run { yield }
+      circuit.run(circuitbox_exceptions: false) { yield }
     end
   end
 end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -65,4 +65,10 @@ class CircuitboxTest < Minitest::Test
     assert_equal 1337, circuit_two.option_value(:sleep_window)
     assert_equal [Timeout::Error], circuit_two.exceptions
   end
+
+  def test_run_sets_circuit_exceptions_to_false
+    Circuitbox::CircuitBreaker.any_instance.expects(:run).with(circuitbox_exceptions: false)
+
+    Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]) { }
+  end
 end


### PR DESCRIPTION
Previous behavior of Circuitbox.circuit would not raise circuitbox exceptions. This unfortunately wasn't updated when the run methods were simplified.