### PR TITLE
Remove Circuitbox "array" based circuit lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Resources about the circuit breaker pattern:
 ## Usage
 
 ```ruby
-Circuitbox[:your_service, exceptions: [Net::ReadTimeout]] do
+Circuitbox.circuit(:your_service, exceptions: [Net::ReadTimeout]) do
   Net::HTTP.get URI('http://example.com/api/messages')
 end
 ```

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -12,10 +12,6 @@ class Circuitbox
   class << self
     include Configuration
 
-    def [](service_name, options = {})
-      circuit(service_name, options)
-    end
-
     def circuit(service_name, options = {})
       circuit = (cached_circuits[service_name] ||= CircuitBreaker.new(service_name, options))
 

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -12,7 +12,7 @@ class Circuitbox
   class << self
     include Configuration
 
-    def circuit(service_name, options = {})
+    def circuit(service_name, options)
       circuit = (cached_circuits[service_name] ||= CircuitBreaker.new(service_name, options))
 
       return circuit unless block_given?

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -43,13 +43,8 @@ class CircuitboxTest < Minitest::Test
     assert_equal timer, Circuitbox.default_timer
   end
 
-  def test_delegates_to_circuit
-    Circuitbox.expects(:circuit).with(:yammer, {})
-    Circuitbox[:yammer]
-  end
-
   def test_creates_a_circuit_breaker
-    assert Circuitbox[:yammer, exceptions: [Timeout::Error]].is_a? Circuitbox::CircuitBreaker
+    assert Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]).is_a? Circuitbox::CircuitBreaker
   end
 
   def test_returns_the_same_circuit_every_time


### PR DESCRIPTION
The ```Circuitbox[]``` lookup was confusing because it handled both creating a circuit and getting an existing circuit. This meant that if options were not passed along it could fail if the circuit had not been created already, but succeed if the circuit was already created. ```Circuitbox.circuit``` should be used going forward. Also In this PR the optional options hash  on ```Circuitbox.circuit``` becomes required.