### PR TITLE
Update the circuit store before sending a notification for the event

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -170,14 +170,14 @@ class Circuitbox
     end
 
     def success!
-      notify_and_increment_event('success')
+      increment_and_notify_event('success')
       logger.debug(circuit_success_message)
 
       close! if half_open?
     end
 
     def failure!
-      notify_and_increment_event('failure')
+      increment_and_notify_event('failure')
       logger.debug(circuit_failure_message)
 
       if half_open?
@@ -197,10 +197,10 @@ class Circuitbox
       notifier.notify(service, event)
     end
 
-    # Send notification and increment stat store
-    def notify_and_increment_event(event)
-      notify_event(event)
+    # Increment stat store and send notification
+    def increment_and_notify_event(event)
       circuit_store.increment(stat_storage_key(event), 1, expires: (option_value(:time_window) * 2))
+      notify_event(event)
     end
 
     def check_sleep_window

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -347,7 +347,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_records_response_failure
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    circuit.expects(:notify_and_increment_event).with('failure')
+    circuit.expects(:increment_and_notify_event).with('failure')
     emulate_circuit_run(circuit, :failure, Timeout::Error)
   end
 
@@ -361,7 +361,7 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_records_response_success
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    circuit.expects(:notify_and_increment_event).with('success')
+    circuit.expects(:increment_and_notify_event).with('success')
     emulate_circuit_run(circuit, :success, 'success')
   end
 
@@ -408,13 +408,13 @@ class CircuitBreakerTest < Minitest::Test
 
   def test_logs_and_retrieves_success_events
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    5.times { circuit.send(:notify_and_increment_event, 'success') }
+    5.times { circuit.send(:increment_and_notify_event, 'success') }
     assert_equal 5, circuit.success_count
   end
 
   def test_logs_and_retrieves_failure_events
     circuit = Circuitbox::CircuitBreaker.new(:yammer, exceptions: [Timeout::Error])
-    5.times { circuit.send(:notify_and_increment_event, 'failure') }
+    5.times { circuit.send(:increment_and_notify_event, 'failure') }
     assert_equal 5, circuit.failure_count
   end
 
@@ -423,19 +423,19 @@ class CircuitBreakerTest < Minitest::Test
     current_time = Time.new(2015, 7, 29)
 
     Timecop.freeze(current_time) do
-      4.times { circuit.send(:notify_and_increment_event, 'success') }
+      4.times { circuit.send(:increment_and_notify_event, 'success') }
       assert_equal 4, circuit.success_count
     end
 
     # one minute after current_time
     Timecop.freeze(current_time + 60) do
-      7.times { circuit.send(:notify_and_increment_event, 'success') }
+      7.times { circuit.send(:increment_and_notify_event, 'success') }
       assert_equal 7, circuit.success_count
     end
 
     # one minute 30 seconds after current_time
     Timecop.freeze(current_time + 90) do
-      circuit.send(:notify_and_increment_event, 'success')
+      circuit.send(:increment_and_notify_event, 'success')
       assert_equal 8, circuit.success_count
     end
 


### PR DESCRIPTION
Previously we would send a notification about an event before updating the circuit store. It's possible for the notifier to be replaced with something that could take a bit of time. Now we'll update the store before the notification is sent.