### PR TITLE
Relax specification for bundler

### DIFF
--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['README.md', 'LICENSE', 'lib/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '> 1.16'
   spec.add_development_dependency 'excon', '~> 0.62'
   spec.add_development_dependency 'faraday', '~> 0.15'
   spec.add_development_dependency 'gimme', '~> 0.5'


### PR DESCRIPTION
Bundler 2.0 was released in January, 2019, so version 1.16 is pretty old.

Relaxed specification to allow versions greater than 1.16 instead of `~> 1.16`.