### PR TITLE
Require Faraday to be at least 1.0.0

### DIFF
--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'excon', '~> 0.62'
-  spec.add_development_dependency 'faraday', '> 1.0.0'
+  spec.add_development_dependency 'faraday', '~> 1.0.0'
   spec.add_development_dependency 'gimme', '~> 0.5'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'minitest-excludes', '~> 2.0'

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'excon', '~> 0.62'
-  spec.add_development_dependency 'faraday', '~> 0.15'
+  spec.add_development_dependency 'faraday', '> 1.0.0'
   spec.add_development_dependency 'gimme', '~> 0.5'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'minitest-excludes', '~> 2.0'

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -31,7 +31,7 @@ class Circuitbox
     }.freeze
 
     DEFAULT_EXCEPTIONS = [
-      Faraday::Error::TimeoutError,
+      Faraday::TimeoutError,
       RequestFailed
     ].freeze
 

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -77,7 +77,7 @@ class Circuitbox
       middleware = FaradayMiddleware.new(app)
       circuit_breaker_options = middleware.opts[:circuit_breaker_options]
 
-      assert_includes circuit_breaker_options[:exceptions], Faraday::Error::TimeoutError
+      assert_includes circuit_breaker_options[:exceptions], Faraday::TimeoutError
       assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
     end
 


### PR DESCRIPTION
Faraday's [1.0.0](https://github.com/lostisland/faraday/releases/tag/v1.0.0) release has changed how its error classes are named here: https://github.com/lostisland/faraday/pull/841.

Now `Faraday::Error::TimeoutError` is `Faraday::TimeoutError`.

Since there is a 2.0 pre-release here, I'm suggesting adding this version here.

There are some gems such as [Raven Ruby](https://github.com/getsentry/raven-ruby) that are requiring Faraday to be > 1.0.

Making impossible to have both versions at the same time.