### PR TITLE
Add support for faraday 1.0 error classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ gemfile: ci/Gemfile
 env:
   - ACTIVE_SUPPORT=true
   - NO_ACTIVE_SUPPORT=true
+  - ACTIVE_SUPPORT=true FARADAY_VERSION=0.17
+  - NO_ACTIVE_SUPPORT=true FARADAY_VERSION=0.17
+  # Faraday < 0.9.0 doesn't support the new error class format
+  - ACTIVE_SUPPORT=true FARADAY_VERSION=0.8.0
+  - NO_ACTIVE_SUPPORT=true FARADAY_VERSION=0.8.0
 rvm:
   - 2.3.8
   - 2.4.6

--- a/ci/Gemfile
+++ b/ci/Gemfile
@@ -4,4 +4,8 @@ if ENV['ACTIVE_SUPPORT']
   gem 'activesupport'
 end
 
+faraday_version = ENV['FARADAY_VERSION'] || '1.0.0'
+
+gem 'faraday', "~> #{faraday_version}"
+
 gemspec(path: '../')

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'excon', '~> 0.62'
-  spec.add_development_dependency 'faraday', '~> 0.15'
+  spec.add_development_dependency 'faraday', ['>= 0.15', '< 2.0']
   spec.add_development_dependency 'gimme', '~> 0.5'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'minitest-excludes', '~> 2.0'

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -31,7 +31,10 @@ class Circuitbox
     }.freeze
 
     DEFAULT_EXCEPTIONS = [
-      Faraday::Error::TimeoutError,
+      # Faraday before 0.9.0 didn't have Faraday::TimeoutError so we default to Faraday::Error::TimeoutError
+      # Faraday >= 0.9.0 defines Faraday::TimeoutError and this can be used for all versions up to 1.0.0 that
+      # also define and raise Faraday::Error::TimeoutError as Faraday::TimeoutError is an ancestor
+      defined?(Faraday::TimeoutError) ? Faraday::TimeoutError : Faraday::Error::TimeoutError,
       RequestFailed
     ].freeze
 

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 require 'moneta'
 require 'circuitbox/faraday_middleware'
+require 'rubygems'
 
 class SentialException < StandardError; end
 
@@ -77,7 +78,13 @@ class Circuitbox
       middleware = FaradayMiddleware.new(app)
       circuit_breaker_options = middleware.opts[:circuit_breaker_options]
 
-      assert_includes circuit_breaker_options[:exceptions], Faraday::Error::TimeoutError
+      faraday_version = Gem::Version.new(Faraday::VERSION).segments
+      faraday_major = faraday_version[0]
+      faraday_minor = faraday_version[1]
+
+      faraday_exception = faraday_major > 0 || faraday_minor > 8 ? Faraday::TimeoutError : Faraday::Error::TimeoutError
+
+      assert_includes circuit_breaker_options[:exceptions], faraday_exception
       assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
     end
 


### PR DESCRIPTION
Faraday 1.0.0 removes accessing exceptions under ```Faraday::Error``` so we need to update the default exceptions in the faraday middleware. The new format of exceptions has existed since ```0.9.0``` allowing us to use the new namespace if it's defined, otherwise using the old ```Faraday::Error``` namespace.