### PR TITLE
Bump to 2.0.0.pre3

### DIFF
--- a/lib/circuitbox/version.rb
+++ b/lib/circuitbox/version.rb
@@ -1,3 +1,3 @@
 class Circuitbox
-  VERSION = '2.0.0.pre2'.freeze
+  VERSION = '2.0.0.pre3'.freeze
 end


### PR DESCRIPTION
Changes from pre2

- faraday middleware supports faraday 2.0
