### PR TITLE
Reduce the amount of jobs that are sent to travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
+Gemfile*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 dist: bionic
 language: ruby
-gemfile: ci/Gemfile
-env:
-  - ACTIVE_SUPPORT=true
-  - NO_ACTIVE_SUPPORT=true
-  - ACTIVE_SUPPORT=true FARADAY_VERSION=0.17
-  - NO_ACTIVE_SUPPORT=true FARADAY_VERSION=0.17
-  # Faraday < 0.9.0 doesn't support the new error class format
-  - ACTIVE_SUPPORT=true FARADAY_VERSION=0.8.0
-  - NO_ACTIVE_SUPPORT=true FARADAY_VERSION=0.8.0
-rvm:
-  - 2.4.10
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
 before_install:
    - gem install bundler
+jobs:
+  include:
+    - name: "2.4 tests"
+      rvm: 2.4.10
+      script: ./test.sh
+    - name: "2.5 tests"
+      rvm: 2.5.8
+      script: ./test.sh
+    - name: "2.6 tests"
+      rvm: 2.6.6
+      script: ./test.sh
+    - name: "2.7 tests"
+      rvm: 2.7.1
+      script: ./test.sh
+    - name: "Lint"
+      rvm: 2.7.1
+      script: bundle exec rubocop

--- a/ci/Gemfile.activesupport
+++ b/ci/Gemfile.activesupport
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 5.2.0'
+
 gem 'faraday', "~> 1.0.0"
 
 gemspec(path: '../')

--- a/ci/Gemfile.oldfaraday
+++ b/ci/Gemfile.oldfaraday
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'faraday', "~> 1.0.0"
+gem 'faraday', "~> 0.8.0"
 
 gemspec(path: '../')

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '> 1.16'
   spec.add_development_dependency 'excon', '~> 0.71'
-  spec.add_development_dependency 'faraday', ['>= 0.15', '< 2.0']
+  spec.add_development_dependency 'faraday', ['>= 0.8', '< 2.0']
   spec.add_development_dependency 'gimme', '~> 0.5'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'minitest-excludes', '~> 2.0'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+function run_tests {
+  export BUNDLE_GEMFILE=$1
+
+  cat <<-TESTMSG
+
+#####################################
+#
+# Running tests with $BUNDLE_GEMFILE
+#
+#####################################
+
+TESTMSG
+
+  bundle install
+  bundle exec rake
+}
+
+run_tests "ci/Gemfile"
+
+run_tests "ci/Gemfile.activesupport"
+
+run_tests "ci/Gemfile.oldfaraday"
+

--- a/test/excludes/NotifierActiveSupportTest.rb
+++ b/test/excludes/NotifierActiveSupportTest.rb
@@ -1,4 +1,6 @@
-unless ENV['ACTIVE_SUPPORT']
+if Gem.loaded_specs.has_key?('activesupport')
+  require 'active_support'
+else
   exclude :test_sends_notification_on_notify, "Uses Activesupport"
   exclude :test_sends_warning_notificaiton_notify_warning, "Uses Activesupport"
   exclude :test_sends_metric_as_notification, "Uses Activesupport"


### PR DESCRIPTION
The current travis configuration has quite a bit of builds which create quite a bit of overhead in the time one waits for tests to run. Since our test suite is pretty small I put together a small test runner that runs the suite against multiple gemfiles. This should achieve the same goal, testing against multiple dependencies, that the current travis-ci config does.

An additional benefit is lint will now run in travis-ci.