### PR TITLE
Add action that builds gem and publishes as a GitHub release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,66 @@
+name: Create Release
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Ruby 2.7
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Setup ENV
+      id: custom-env
+      run: |
+        export CIRCUITBOX_VERSION=$(echo ${RELEASE_TAG} | cut -c2-)
+        echo "::set-output name=gem_filename::circuitbox-${CIRCUITBOX_VERSION}.gem"
+
+        if echo $CIRCUITBOX_VERSION | grep -q "pre"
+        then
+          echo "::set-output name=gem_prerelease::true"
+        else
+          echo "::set-output name=gem_prerelease::false"
+        fi
+      env:
+        RELEASE_TAG: ${{ github.ref }}
+    - name: Build Gem
+      run: |
+        gem build circuitbox.gemspec
+        test -f ${{ steps.custom-env.outputs.gem_filename }}
+    - name: Generate Sha256sum
+      run: |
+        shasum -a 256 ${{ steps.custom-env.outputs.gem_filename }} > SHASUMS256.txt
+        cat SHASUMS256.txt
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: ${{ steps.custom-env.outputs.gem_prerelease }}
+    - name: Upload Gem
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./${{ steps.custom-env.outputs.gem_filename }}
+        asset_name: ${{ steps.custom-env.outputs.gem_filename }}
+        asset_content_type: application/x-tar
+    - name: Upload SHASUMS256.txt
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./SHASUMS256.txt
+        asset_name: SHASUMS256.txt
+        asset_content_type: text/plain


### PR DESCRIPTION
For all previous releases someone has had to build the gem and publish it to ruby gems but there was no transparency as to how the release was built and what it contains. With the build happening as an action when a tag is pushed one can look at the sha from the build machine and compare it to the release asset, this can be then verified with the gem that's published to ruby gems.