### PR TITLE
Rename execution_timer to timer and the execution_time metric to runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ class ExampleServiceClient
       logger: Logger.new(STDOUT),
 
       # Customized Timer object
-      # Use NullTimer if you don't want to time circuit execution
+      # Use NullTimer if you don't want to time circuit runtime
       # Use MonotonicTimer to avoid bad time metrics on system time resync
       # This overrides what is set in the global configuration
-      execution_timer: SimpleTimer,
+      timer: SimpleTimer,
 
       # Customized notifier
       # overrides the default
@@ -168,7 +168,7 @@ end
 
 `payload[:gauge]` can be:
 
-- `execution_time` # execution time will only be notified when circuit is closed and block is successfully executed.
+- `runtime` # runtime will only be notified when circuit is closed and block is successfully executed.
 
 **warnings:**
 in case of misconfiguration, circuitbox will fire a circuitbox_warning

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -7,7 +7,7 @@ class Circuitbox
     include LoggerMessages
 
     attr_reader :service, :circuit_options, :exceptions,
-                :logger, :circuit_store, :notifier, :time_class, :execution_timer
+                :logger, :circuit_store, :notifier, :time_class, :timer
 
     DEFAULTS = {
       sleep_window: 90,
@@ -30,7 +30,7 @@ class Circuitbox
       @service = service.to_s
       @circuit_options = DEFAULTS.merge(options)
       @circuit_store   = options.fetch(:cache) { Circuitbox.default_circuit_store }
-      @execution_timer = options.fetch(:execution_timer) { Circuitbox.default_timer }
+      @timer = options.fetch(:timer) { Circuitbox.default_timer }
       @notifier = options.fetch(:notifier) { Circuitbox.default_notifier }
 
       if @circuit_options[:timeout_seconds]
@@ -60,7 +60,7 @@ class Circuitbox
         logger.debug(circuit_running_message)
 
         begin
-          response = execution_timer.time(service, notifier, 'execution_time', &block)
+          response = timer.time(service, notifier, 'runtime', &block)
 
           success!
         rescue *exceptions => e

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -502,43 +502,43 @@ class CircuitBreakerTest < Minitest::Test
       assert_equal false, notifier.notified?, 'no notification sent'
     end
 
-    def test_not_notify_circuit_execution_time_on_null_timer
-      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
+    def test_not_notify_circuit_runtime_on_null_timer
+      notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
       timer = Circuitbox::Timer::Null.new
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
-                                              execution_timer: timer,
-                                              exceptions: [Timeout::Error])
+                                               timer: timer,
+                                               exceptions: [Timeout::Error])
       circuit.run { 'success' }
-      refute notifier.metric_sent?, 'execution time metric sent'
+      refute notifier.metric_sent?, 'runtime metric sent'
     end
 
-    def test_send_execution_time_metric
-      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
+    def test_send_runtime_metric
+      notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
       circuit.run { 'success' }
-      assert notifier.metric_sent?, 'no execution time metric sent'
+      assert notifier.metric_sent?, 'no runtime metric sent'
     end
 
-    def test_no_execution_time_metric_on_error_execution
-      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
+    def test_no_runtime_metric_on_error
+      notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
       circuit.run(circuitbox_exceptions: false) { raise Timeout::Error }
-      refute notifier.metric_sent?, 'execution time metric sent'
+      refute notifier.metric_sent?, 'runtime metric sent'
     end
 
-    def test_no_execution_time_metric_when_circuit_open
-      notifier = gimme_notifier(metric: 'execution_time', metric_value: Gimme::Matchers::Anything.new)
+    def test_no_runtime_metric_when_circuit_open
+      notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                notifier: notifier,
                                                exceptions: [Timeout::Error])
       circuit.send(:trip)
       circuit.run(circuitbox_exceptions: false) { raise Timeout::Error }
-      refute notifier.metric_sent?, 'execution time metric sent'
+      refute notifier.metric_sent?, 'runtime metric sent'
     end
 
     def gimme_notifier(opts = {})


### PR DESCRIPTION
The timer classes are already pretty generic and could be used to time anything so we shouldn't restrict them to just circuit execution. Also runtime sounds like a better name then execution_time.