### PR TITLE
Fix some common issues in the test suite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
-require: rubocop-performance
+require:
+  - rubocop-minitest
+  - rubocop-performance
+  - rubocop-rake
 
 AllCops:
   Exclude:

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -35,7 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '1.8.1'
+  spec.add_development_dependency 'rubocop-minitest', '0.10.3'
   spec.add_development_dependency 'rubocop-performance', '1.9.2'
+  spec.add_development_dependency 'rubocop-rake', '0.5.1'
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'typhoeus', '~> 1.3'
 end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -16,7 +16,7 @@ class CircuitboxTest < Minitest::Test
 
   def test_configure_block_clears_cached_circuits
     Circuitbox.expects(:clear_cached_circuits!)
-    Circuitbox.configure {}
+    Circuitbox.configure { 'no config' }
   end
 
   def test_default_circuit_store_is_configurable
@@ -64,6 +64,6 @@ class CircuitboxTest < Minitest::Test
   def test_run_sets_circuit_exceptions_to_false
     Circuitbox::CircuitBreaker.any_instance.expects(:run).with(circuitbox_exceptions: false)
 
-    Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]) { }
+    Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]) { 'success' }
   end
 end

--- a/test/excon_middleware_test.rb
+++ b/test/excon_middleware_test.rb
@@ -7,7 +7,7 @@ class SentialException < StandardError; end
 
 class Circuitbox
   class ExconMiddlewareTest < Minitest::Test
-    attr_reader :app
+    attr_reader :app, :circuitbox, :circuit
 
     def setup
       @app = gimme
@@ -21,7 +21,7 @@ class Circuitbox
 
     def test_overwrite_identifier
       middleware = ExconMiddleware.new(app, identifier: 'sential')
-      assert_equal middleware.identifier, 'sential'
+      assert_equal 'sential', middleware.identifier
     end
 
     def test_overwrite_default_value_generator_lambda
@@ -58,7 +58,7 @@ class Circuitbox
       mw = ExconMiddleware.new(app, open_circuit: error_response)
       response = mw.response_call(env)
       assert_kind_of Excon::Response, response
-      assert_equal response.status, 400
+      assert_equal 400, response.status
     end
 
     def test_default_success_response
@@ -70,7 +70,7 @@ class Circuitbox
       response = mw.response_call(env)
 
       assert_kind_of Excon::Response, response
-      assert_equal response.status, 503
+      assert_equal 503, response.status
     end
 
     def test_overwrite_exceptions
@@ -90,7 +90,7 @@ class Circuitbox
       middleware = ExconMiddleware.new(app, options)
       middleware.request_call(env)
 
-      verify(circuitbox, 1.times).circuit('yammer.com', expected_circuit_breaker_options)
+      verify(circuitbox).circuit('yammer.com', expected_circuit_breaker_options)
     end
 
     def test_overwrite_circuitbreaker_default_value
@@ -99,7 +99,7 @@ class Circuitbox
       give(circuitbox).circuit('yammer.com', anything) { circuit }
       give(circuit).run { raise Circuitbox::Error }
       middleware = ExconMiddleware.new(app, circuitbox: circuitbox)
-      assert_equal middleware.error_call(env), :sential
+      assert_equal :sential, middleware.error_call(env)
     end
 
     def test_return_null_response_for_open_circuit
@@ -110,10 +110,9 @@ class Circuitbox
       mw = ExconMiddleware.new(app, circuitbox: circuitbox)
       response = mw.error_call(env)
       assert_kind_of Excon::Response, response
-      assert_equal response.status, 503
+      assert_equal 503, response.status
     end
 
-    attr_reader :circuitbox, :circuit
     def stub_circuitbox
       @circuitbox = gimme
       @circuit = gimme

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -27,7 +27,7 @@ class Circuitbox
       middleware = FaradayMiddleware.new(app)
       uri = gimme
       give(uri).host { nil }
-      give(uri).to_s { 'yam'}
+      give(uri).to_s { 'yam' }
       env = { url: uri }
 
       assert_equal 'yam', middleware.opts[:identifier].call(env)
@@ -36,7 +36,7 @@ class Circuitbox
     def test_overwrite_identifier
       middleware = FaradayMiddleware.new(app, identifier: 'sential')
 
-      assert_equal middleware.opts[:identifier], 'sential'
+      assert_equal 'sential', middleware.opts[:identifier]
     end
 
     def test_overwrite_default_value_generator_lambda
@@ -55,7 +55,7 @@ class Circuitbox
       circuit = gimme
       env = { url: URI('http://yammer.com/') }
 
-      give(circuit).run { raise Circuitbox::Error, 'error text' }
+      give(circuit).run { raise Circuitbox::Error.new('error text') }
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       default_value_generator = ->(_, error) { error.message }
@@ -82,7 +82,7 @@ class Circuitbox
       faraday_major = faraday_version[0]
       faraday_minor = faraday_version[1]
 
-      faraday_exception = faraday_major > 0 || faraday_minor > 8 ? Faraday::TimeoutError : Faraday::Error::TimeoutError
+      faraday_exception = faraday_major.positive? || faraday_minor > 8 ? Faraday::TimeoutError : Faraday::Error::TimeoutError
 
       assert_includes circuit_breaker_options[:exceptions], faraday_exception
       assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
@@ -95,7 +95,7 @@ class Circuitbox
       error_response = ->(_) { false }
       response = FaradayMiddleware.new(app, open_circuit: error_response).call(env)
       assert_kind_of Faraday::Response, response
-      assert_equal response.status, 500
+      assert_equal 500, response.status
       assert response.finished?
       refute response.success?
     end
@@ -106,7 +106,7 @@ class Circuitbox
       give(app).call(anything) { Faraday::Response.new(status: 500) }
       response = FaradayMiddleware.new(app).call(env)
       assert_kind_of Faraday::Response, response
-      assert_equal response.status, 503
+      assert_equal 503, response.status
       assert response.finished?
       refute response.success?
     end
@@ -117,7 +117,7 @@ class Circuitbox
       give(app).call(anything) { Faraday::Response.new(status: 400) }
       response = FaradayMiddleware.new(app).call(env)
       assert_kind_of Faraday::Response, response
-      assert_equal response.status, 400
+      assert_equal 400, response.status
       assert response.finished?
       refute response.success?
     end
@@ -128,7 +128,7 @@ class Circuitbox
       give(app).call(anything) { Faraday::Response.new(status: nil) }
       response = FaradayMiddleware.new(app).call(env)
       assert_kind_of Faraday::Response, response
-      assert_equal response.status, 503
+      assert_equal 503, response.status
       assert response.finished?
       refute response.success?
     end
@@ -162,7 +162,7 @@ class Circuitbox
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       middleware = FaradayMiddleware.new(app)
-      assert_equal middleware.call(env), :sential
+      assert_equal :sential, middleware.call(env)
     end
 
     def test_return_value_closed_circuit
@@ -173,7 +173,7 @@ class Circuitbox
       Circuitbox.expects(:circuit).with('yammer.com', anything).returns(circuit)
 
       middleware = FaradayMiddleware.new(app)
-      assert_equal middleware.call(env), :sential
+      assert_equal :sential, middleware.call(env)
     end
 
     def test_return_null_response_for_open_circuit
@@ -185,7 +185,7 @@ class Circuitbox
 
       response = FaradayMiddleware.new(app).call(env)
       assert_kind_of Faraday::Response, response
-      assert_equal response.status, 503
+      assert_equal 503, response.status
       assert response.finished?
       refute response.success?
     end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -30,7 +30,7 @@ class FakeServer
 
   def create(port, result)
     @servers << Thread.new do
-      Rack::Handler::WEBrick.run(Proc.new { |env| result },
+      Rack::Handler::WEBrick.run(proc { |_env| result },
                                  Port: port,
                                  AccessLog: [],
                                  Logger: WEBrick::Log.new(DEV_NULL))
@@ -40,9 +40,8 @@ class FakeServer
 end
 
 module IntegrationHelpers
-  def open_circuit(c = connection)
+  def open_circuit(conn = connection)
     volume_threshold = Circuitbox::CircuitBreaker::DEFAULTS[:volume_threshold]
-    (volume_threshold + 1).times { c.get(failure_url) }
+    (volume_threshold + 1).times { conn.get(failure_url) }
   end
 end
-

--- a/test/memory_store_test.rb
+++ b/test/memory_store_test.rb
@@ -111,7 +111,7 @@ class MemoryStoreTest < Minitest::Test
   end
 
   def test_key_returns_false_when_key_is_not_set
-    assert_equal false, @memory_store.key?('test')
+    refute @memory_store.key?('test')
   end
 
   def test_key_returns_false_when_key_is_expired
@@ -121,7 +121,7 @@ class MemoryStoreTest < Minitest::Test
                                       .returns(container)
     @memory_store.store('test', 1)
     container.expects(:expired_at?).returns(true)
-    assert_equal false, @memory_store.key?('test')
+    refute @memory_store.key?('test')
   end
 
   def test_key_compacts_store
@@ -137,6 +137,6 @@ class MemoryStoreTest < Minitest::Test
     @memory_store.store('test', 1)
 
     @memory_store.delete('test')
-    assert_equal false, @memory_store.key?('test')
+    refute @memory_store.key?('test')
   end
 end

--- a/test/service_failure_error_test.rb
+++ b/test/service_failure_error_test.rb
@@ -6,9 +6,9 @@ class ServiceFailureErrorTest < Minitest::Test
   attr_reader :error
 
   def setup
-    raise SomeOtherError, "some other error"
-  rescue => ex
-    @error = ex
+    raise SomeOtherError.new("some other error")
+  rescue SomeOtherError => e
+    @error = e
   end
 
   def test_includes_the_message_of_the_wrapped_exception


### PR DESCRIPTION
- Moved assert equal  false / negated assert to refute
- Corrected the order of assert_equal
- Filled empty circuit blocks with a string
- Made exceptions have the same format as Circuitbox exceptions