### PR TITLE
Always emit runtime metric when running block

### DIFF
--- a/lib/circuitbox/timer.rb
+++ b/lib/circuitbox/timer.rb
@@ -29,10 +29,10 @@ class Circuitbox
     class << self
       def measure(service, notifier, metric_name)
         before = now
-        result = yield
+        yield
+      ensure
         total_time = now - before
         notifier.metric_gauge(service, metric_name, total_time)
-        result
       end
 
       private

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -528,15 +528,6 @@ class CircuitBreakerTest < Minitest::Test
       assert notifier.metric_sent?, 'no runtime metric sent'
     end
 
-    def test_no_runtime_metric_on_error
-      notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
-      circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                               notifier: notifier,
-                                               exceptions: [Timeout::Error])
-      circuit.run(circuitbox_exceptions: false) { raise Timeout::Error }
-      refute notifier.metric_sent?, 'runtime metric sent'
-    end
-
     def test_no_runtime_metric_when_circuit_open
       notifier = gimme_notifier(metric: 'runtime', metric_value: Gimme::Matchers::Anything.new)
       circuit = Circuitbox::CircuitBreaker.new(:yammer,


### PR DESCRIPTION
Currently if the block a circuit is running raises an exception the runtime metric is not emitted. This makes it a little difficult when on-call and looking at charts to see what the circuit runtime is with errors.

With this change we'll always send the metric when the block is run which should help pinpoint potential issues.