### PR TITLE
Clarify option names with units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Faraday middleware supports faraday 1.0 [\#143](https://github.com/yammer/circuitbox/pull/143)
 - Remove ```run!``` method and change ```run``` method (see upgrade guide) [\#119](https://github.com/yammer/circuitbox/pull/119) [\#126](https://github.com/yammer/circuitbox/pull/126)
 - Correctly check a circuits volume threshold [\#116](https://github.com/yammer/circuitbox/pull/116)
-- Stop overwriting sleep_window when it is less than time window [\#108](https://github.com/yammer/circuitbox/pull/108)
+- Stop overwriting sleep_window_sec when it is less than time_window_sec [\#108](https://github.com/yammer/circuitbox/pull/108)
 - Lower default sleep window from 300 seconds (5 minutes) to 90 seconds (1 minute 30 seconds) [\#107](https://github.com/yammer/circuitbox/pull/107)
 - Remove Circuitbox's use of ruby timeout [\#106](https://github.com/yammer/circuitbox/pull/106)
 - Register faraday middleware [\#104](https://github.com/yammer/circuitbox/pull/104)

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ class ExampleServiceClient
       exceptions:       [YourCustomException],
 
       # seconds the circuit stays open once it has passed the error threshold
-      sleep_window:     300,
+      sleep_window_sec:     300,
 
       # length of interval (in seconds) over which it calculates the error rate
-      time_window:      60,
+      time_window_sec:      60,
 
-      # number of requests within `time_window` seconds before it calculates error rates (checked on failures)
+      # number of requests within `time_window_sec` seconds before it calculates error rates (checked on failures)
       volume_threshold: 10,
 
       # the store you want to use to save the circuit state so it can be
@@ -84,7 +84,7 @@ class ExampleServiceClient
       cache: Circuitbox::MemoryStore.new,
 
       # exceeding this rate will open the circuit (checked on failures)
-      error_threshold:  50,
+      error_percent_threshold:  50,
 
       # Logger to use
       # This overrides what is set in the global configuration
@@ -103,7 +103,7 @@ You can also pass a Proc as an option value which will evaluate each time the ci
 
 ```ruby
 Circuitbox.circuit(:yammer, {
-  sleep_window: Proc.new { Configuration.get(:sleep_window) },
+  sleep_window_sec: Proc.new { Configuration.get(:sleep_window_sec) },
   exceptions: [Net::ReadTimeout]
 })
 ```

--- a/benchmark/object_usage_benchmark.rb
+++ b/benchmark/object_usage_benchmark.rb
@@ -16,15 +16,15 @@ logger = Logger.new($stdout)
 logger.level = Logger::WARN # so we don't output any debug info
 
 circuits_to_test << Circuitbox::CircuitBreaker.new('circuitbox_memory_store',
-                                                   sleep_window: 2,
-                                                   time_window: 1,
+                                                   sleep_window_sec: 2,
+                                                   time_window_sec: 1,
                                                    logger: logger,
                                                    exceptions: [StandardError],
                                                    cache: Circuitbox::MemoryStore.new)
 
 circuits_to_test << Circuitbox::CircuitBreaker.new('moneta_memory_store',
-                                                   sleep_window: 2,
-                                                   time_window: 1,
+                                                   sleep_window_sec: 2,
+                                                   time_window_sec: 1,
                                                    logger: logger,
                                                    exceptions: [StandardError],
                                                    cache: Moneta.new(:Memory, expires: true, threadsafe: true))
@@ -45,9 +45,9 @@ class ObjectUsageBenchmark
             raise StandardError if total_iterations % 4
           end
 
-          # by sleeping we end up causing the circuit to go through
-          # multiple time_window's when the iteration count is high
-          # and the time window is low.
+          # by sleeping, we end up causing the circuit to go through
+          # multiple time windows when the iteration count is high
+          # and time_window_sec is low.
           sleep 0.1
 
           next unless (total_iterations % report_every).zero?

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -27,9 +27,9 @@ class CircuitBreakerTest < Minitest::Test
       end
 
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                                sleep_window: 300,
+                                                sleep_window_sec: 300,
                                                 volume_threshold: 5,
-                                                error_threshold: 33,
+                                                error_percent_threshold: 33,
                                                 exceptions: [Timeout::Error])
     end
 
@@ -194,10 +194,10 @@ class CircuitBreakerTest < Minitest::Test
       end
 
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                                sleep_window: 2,
-                                                time_window: 2,
+                                                sleep_window_sec: 2,
+                                                time_window_sec: 2,
                                                 volume_threshold: 5,
-                                                error_threshold: 50,
+                                                error_percent_threshold: 50,
                                                 exceptions: [Timeout::Error])
     end
 
@@ -215,9 +215,9 @@ class CircuitBreakerTest < Minitest::Test
 
       # We need to be past the sleep window for the circuit to close
       # which is why we are adding 1 second to the sleep window
-      approximate_sleep_window = @circuit.option_value(:sleep_window) + 1
+      approximate_sleep_window_sec = @circuit.option_value(:sleep_window_sec) + 1
 
-      Timecop.freeze(current_time + approximate_sleep_window) do
+      Timecop.freeze(current_time + approximate_sleep_window_sec) do
         @circuit.run { run_count += 1 }
       end
 
@@ -237,10 +237,10 @@ class CircuitBreakerTest < Minitest::Test
       end
 
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                                sleep_window: 2,
-                                                time_window: 2,
+                                                sleep_window_sec: 2,
+                                                time_window_sec: 2,
                                                 volume_threshold: 2,
-                                                error_threshold: 50,
+                                                error_percent_threshold: 50,
                                                 exceptions: [Timeout::Error])
     end
 
@@ -312,10 +312,10 @@ class CircuitBreakerTest < Minitest::Test
     current_time = Time.new(2015, 7, 29)
     circuit_ran = false
     circuit = Circuitbox::CircuitBreaker.new(:yammer,
-                                             sleep_window: 2,
-                                             time_window: 2,
+                                             sleep_window_sec: 2,
+                                             time_window_sec: 2,
                                              volume_threshold: 2,
-                                             error_threshold: 50,
+                                             error_percent_threshold: 50,
                                              exceptions: [Timeout::Error])
 
     Timecop.freeze(current_time) do
@@ -508,20 +508,20 @@ class CircuitBreakerTest < Minitest::Test
       _, error = capture_io do
         Circuitbox::CircuitBreaker.new(:yammer,
                                        notifier: notifier,
-                                       sleep_window: 1,
-                                       time_window: 10,
+                                       sleep_window_sec: 1,
+                                       time_window_sec: 10,
                                        exceptions: [Timeout::Error])
       end
       assert notifier.notified?, 'no notification sent'
-      assert_match(/Circuit: yammer.+sleep_window: 1.+time_window: 10.+/, error)
+      assert_match(/Circuit: yammer.+sleep_window_sec: 1.+time_window_sec: 10.+/, error)
     end
 
     def test_does_not_warn_on_sleep_window_being_correctly_sized
       notifier = gimme_notifier
       Circuitbox::CircuitBreaker.new(:yammer,
                                      notifier: notifier,
-                                     sleep_window: 11,
-                                     time_window: 10,
+                                     sleep_window_sec: 11,
+                                     time_window_sec: 10,
                                      exceptions: [Timeout::Error])
       refute notifier.notified?, 'no notification sent'
     end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -46,11 +46,11 @@ class CircuitboxTest < Minitest::Test
   end
 
   def test_sets_the_circuit_options_the_first_time_only
-    circuit_one = Circuitbox.circuit(:yammer, exceptions: [Timeout::Error], sleep_window: 1337)
-    circuit_two = Circuitbox.circuit(:yammer, exceptions: [StandardError], sleep_window: 2000)
+    circuit_one = Circuitbox.circuit(:yammer, exceptions: [Timeout::Error], sleep_window_sec: 1337)
+    circuit_two = Circuitbox.circuit(:yammer, exceptions: [StandardError], sleep_window_sec: 2000)
 
-    assert_equal 1337, circuit_one.option_value(:sleep_window)
-    assert_equal 1337, circuit_two.option_value(:sleep_window)
+    assert_equal 1337, circuit_one.option_value(:sleep_window_sec)
+    assert_equal 1337, circuit_two.option_value(:sleep_window_sec)
     assert_equal [Timeout::Error], circuit_two.exceptions
   end
 


### PR DESCRIPTION
Adding the units to the option names would remove confusion for readers of code that uses circuitbox.