### PR TITLE
add Circuitbox.open? method to check if a given service's circuit is open

### DIFF
--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -20,5 +20,13 @@ class Circuitbox
 
       circuit.run(circuitbox_exceptions: false, &block)
     end
+
+    def open?(service_name)
+      @cached_circuits_mutex.synchronize do
+        return false unless @cached_circuits[service_name]
+
+        @cached_circuits[service_name].open?
+      end
+    end
   end
 end

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -59,4 +59,19 @@ class CircuitboxTest < Minitest::Test
 
     Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]) { 'success' }
   end
+
+  def test_existing_circuit_is_not_open
+    Circuitbox.circuit(:yammer, exceptions: [Timeout::Error])
+    assert_equal false, Circuitbox.open?(:yammer)
+  end
+
+  def test_existing_circuit_is_open
+    Circuitbox::CircuitBreaker.any_instance.expects(:open?).returns(true)
+    Circuitbox.circuit(:yammer, exceptions: [Timeout::Error])
+    assert_equal true, Circuitbox.open?(:yammer)
+  end
+
+  def test_nonexistent_circuit_is_not_open
+    assert_equal false, Circuitbox.open?(:nonexistent)
+  end
 end


### PR DESCRIPTION
Adds a method to check if a given service name has a circuit and it's open. This makes it easier to check if a circuit is open.