### PR TITLE
Rename ActiveSupport::Notifications events to follow rails conventions

### DIFF
--- a/lib/circuitbox/notifier/active_support.rb
+++ b/lib/circuitbox/notifier/active_support.rb
@@ -4,15 +4,15 @@ class Circuitbox
   class Notifier
     class ActiveSupport
       def notify(circuit_name, event)
-        ::ActiveSupport::Notifications.instrument("circuit_#{event}", circuit: circuit_name)
+        ::ActiveSupport::Notifications.instrument("#{event}.circuitbox", circuit: circuit_name)
       end
 
       def notify_warning(circuit_name, message)
-        ::ActiveSupport::Notifications.instrument('circuit_warning', circuit: circuit_name, message: message)
+        ::ActiveSupport::Notifications.instrument('warning.circuitbox', circuit: circuit_name, message: message)
       end
 
       def notify_run(circuit_name, &block)
-        ::ActiveSupport::Notifications.instrument('circuit_run', circuit: circuit_name, &block)
+        ::ActiveSupport::Notifications.instrument('run.circuitbox', circuit: circuit_name, &block)
       end
     end
   end

--- a/test/notifier/active_support_test.rb
+++ b/test/notifier/active_support_test.rb
@@ -1,31 +1,36 @@
 require 'test_helper'
 
 if ENV['ACTIVE_SUPPORT']
+  require 'active_support'
   require 'active_support/notifications'
   require 'circuitbox/notifier/active_support'
 end
 
 
 class NotifierActiveSupportTest < Minitest::Test
+  def setup
+    @notifier = Circuitbox::Notifier::ActiveSupport.new
+  end
+
   def test_sends_notification_on_notify
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_open", circuit: 'yammer')
-    Circuitbox::Notifier::ActiveSupport.new.notify('yammer', :open)
+    ActiveSupport::Notifications.expects(:instrument).with('open.circuitbox', circuit: 'yammer')
+    @notifier.notify('yammer', :open)
   end
 
   def test_sends_warning_notificaiton_notify_warning
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_warning", { circuit: 'yammer', message: 'hello'})
-    Circuitbox::Notifier::ActiveSupport.new.notify_warning('yammer', 'hello')
+    ActiveSupport::Notifications.expects(:instrument).with('warning.circuitbox', { circuit: 'yammer', message: 'hello'})
+    @notifier.notify_warning('yammer', 'hello')
   end
 
   def test_sends_notification_on_notify_run
-    ActiveSupport::Notifications.expects(:instrument).with("circuit_run", { circuit: 'yammer'})
-    Circuitbox::Notifier::ActiveSupport.new.notify_run('yammer') { 'nothing' }
+    ActiveSupport::Notifications.expects(:instrument).with('run.circuitbox', { circuit: 'yammer'})
+    @notifier.notify_run('yammer') { 'nothing' }
   end
 
   def test_notify_run_runs_the_block
     called = false
 
-    Circuitbox::Notifier::ActiveSupport.new.notify_run('yammer') { called = true }
+    @notifier.notify_run('yammer') { called = true }
 
     assert called
   end


### PR DESCRIPTION
The rails convention for defining events as `event.library` is defined on the [rails 7.0 guides page](https://guides.rubyonrails.org/v7.0/active_support_instrumentation.html#creating-custom-events). While this is a breaking change it would be okay for the 1.x to 2.x upgrade. It's currently possible to change the notifier making it possible for someone to make their own custom one to support the old format if needed.