### PR TITLE
Rename `circuitbox_exceptions` to `exception`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ class ExampleServiceClient
   end
 
   def http_get
-    circuit.run(circuitbox_exceptions: false) do
+    circuit.run(exception: false) do
       Zephyr.new("http://example.com").get(200, 1000, "/api/messages")
     end
   end

--- a/benchmark/object_usage_benchmark.rb
+++ b/benchmark/object_usage_benchmark.rb
@@ -41,7 +41,7 @@ class ObjectUsageBenchmark
         while total_iterations < iterations
           total_iterations += 1
 
-          circuit.run(circuitbox_exceptions: false) do
+          circuit.run(exception: false) do
             raise StandardError if total_iterations % 4
           end
 

--- a/lib/circuitbox.rb
+++ b/lib/circuitbox.rb
@@ -18,7 +18,7 @@ class Circuitbox
 
       return circuit unless block
 
-      circuit.run(circuitbox_exceptions: false, &block)
+      circuit.run(exception: false, &block)
     end
   end
 end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -59,21 +59,21 @@ class Circuitbox
     # If the circuit is closed or half_open the block will run.
     # If the circuit is open the block will not be run.
     #
-    # @param circuitbox_exceptions [Boolean] If exceptions should be raised when the circuit is open
+    # @param exception [Boolean] If exceptions should be raised when the circuit is open
     #   or when a watched exception is raised from the block
     # @yield Block to run if circuit is not open
     #
-    # @raise [Circuitbox::OpenCircuitError] If the circuit is open and circuitbox_exceptions is true
-    # @raise [Circuitbox::ServiceFailureError] If a tracked exception is raised from the block and circuitbox_exceptions is true
+    # @raise [Circuitbox::OpenCircuitError] If the circuit is open and exception is true
+    # @raise [Circuitbox::ServiceFailureError] If a tracked exception is raised from the block and exception is true
     #
     # @return [Object] The result from the block
-    # @return [Nil] If the circuit is open and circuitbox_exceptions is false
+    # @return [Nil] If the circuit is open and exception is false
     #   In cases where an exception that circuitbox is watching is raised from either a notifier
     #   or from a custom circuit cache nil can be returned even though the block ran successfully
-    def run(circuitbox_exceptions: true, &block)
+    def run(exception: true, &block)
       if open?
         skipped!
-        raise Circuitbox::OpenCircuitError.new(service) if circuitbox_exceptions
+        raise Circuitbox::OpenCircuitError.new(service) if exception
       else
         logger.debug(circuit_running_message)
 
@@ -86,7 +86,7 @@ class Circuitbox
           # setting to nil keeps the same behavior as the previous definition of run.
           response = nil
           failure!
-          raise Circuitbox::ServiceFailureError.new(service, e) if circuitbox_exceptions
+          raise Circuitbox::ServiceFailureError.new(service, e) if exception
         end
       end
 

--- a/test/circuitbox_test.rb
+++ b/test/circuitbox_test.rb
@@ -55,7 +55,7 @@ class CircuitboxTest < Minitest::Test
   end
 
   def test_run_sets_circuit_exceptions_to_false
-    Circuitbox::CircuitBreaker.any_instance.expects(:run).with(circuitbox_exceptions: false)
+    Circuitbox::CircuitBreaker.any_instance.expects(:run).with(exception: false)
 
     Circuitbox.circuit(:yammer, exceptions: [Timeout::Error]) { 'success' }
   end


### PR DESCRIPTION
This matches what ruby does for kernel methods that either return nil
or can raise an exception.