### PR TITLE
Add ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,13 +18,13 @@ jobs:
       id: custom-env
       run: |
         export CIRCUITBOX_VERSION=$(echo ${RELEASE_TAG#refs/tags/} | cut -c2-)
-        echo "::set-output name=gem_filename::circuitbox-${CIRCUITBOX_VERSION}.gem"
+        echo "gem_filename=circuitbox-${CIRCUITBOX_VERSION}.gem" >> $GITHUB_OUTPUT
 
         if echo $CIRCUITBOX_VERSION | grep -q "pre"
         then
-          echo "::set-output name=gem_prerelease::true"
+          echo "gem_prerelease=true" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=gem_prerelease::false"
+          echo "gem_prerelease=false" >> $GITHUB_OUTPUT
         fi
       env:
         RELEASE_TAG: ${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: [2.6, 2.7, 3.0, 3.1, 3.2]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
This will now test the changes against ruby 2.6-3.2. Additionally switched set-output to the format mentioned in the GitHub change log https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/