### PR TITLE
Circuit Opening Improvements

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -222,7 +222,8 @@ class Circuitbox
     # Increment stat store and send notification
     def increment_and_notify_event(event)
       time_window = option_value(:time_window)
-      @circuit_store.increment(stat_storage_key(event, time_window), 1, expires: time_window)
+      aligned_time = align_time_to_window(time_window)
+      @circuit_store.increment(stat_storage_key(event, aligned_time), 1, expires: time_window)
       notify_event(event)
     end
 
@@ -237,12 +238,12 @@ class Circuitbox
       warn("Circuit: #{@service}, Warning: #{warning_message}")
     end
 
-    def stat_storage_key(event, window = option_value(:time_window))
-      "circuits:#{@service}:stats:#{align_time_to_window(window)}:#{event}"
+    def stat_storage_key(event, aligned_time = align_time_to_window)
+      "circuits:#{@service}:stats:#{aligned_time}:#{event}"
     end
 
     # return time representation in seconds
-    def align_time_to_window(window)
+    def align_time_to_window(window = option_value(:time_window))
       time = @time_class.now.to_i
       time - (time % window) # remove rest of integer division
     end

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -132,17 +132,16 @@ class Circuitbox
     def should_open?
       failures = failure_count
       successes = success_count
-      rate = error_rate(failures, successes)
 
-      passed_volume_threshold?(failures, successes) && passed_rate_threshold?(rate)
+      passed_volume_threshold?(failures, successes) && passed_rate_threshold?(failures, successes)
     end
 
     def passed_volume_threshold?(failures, successes)
       failures + successes >= option_value(:volume_threshold)
     end
 
-    def passed_rate_threshold?(rate)
-      rate >= option_value(:error_threshold)
+    def passed_rate_threshold?(failures, successes)
+      error_rate(failures, successes) >= option_value(:error_threshold)
     end
 
     def half_open_failure

--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -130,8 +130,16 @@ class Circuitbox
     private
 
     def should_open?
-      failures = failure_count
-      successes = success_count
+      aligned_time = align_time_to_window
+
+      failures, successes = @circuit_store.values_at(stat_storage_key('failure', aligned_time),
+                                                     stat_storage_key('success', aligned_time),
+                                                     raw: true)
+      # Calling to_i is only needed for moneta stores which can return a string representation of an integer.
+      # While readability could increase by adding .map(&:to_i) to the end of the values_at call it's also slightly
+      # less performant when we only have two values to convert.
+      failures = failures.to_i
+      successes = successes.to_i
 
       passed_volume_threshold?(failures, successes) && passed_rate_threshold?(failures, successes)
     end

--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -43,6 +43,13 @@ class Circuitbox
       @mutex.synchronize { fetch_container(key)&.value }
     end
 
+    def values_at(*keys, **_opts)
+      @mutex.synchronize do
+        current_time = current_second
+        keys.map! { |key| fetch_container(key, current_time)&.value }
+      end
+    end
+
     def key?(key)
       @mutex.synchronize { !fetch_container(key).nil? }
     end
@@ -53,9 +60,7 @@ class Circuitbox
 
     private
 
-    def fetch_container(key)
-      current_time = current_second
-
+    def fetch_container(key, current_time = current_second)
       compact(current_time) if @compact_after < current_time
 
       container = @store[key]

--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -40,7 +40,7 @@ class Circuitbox
     end
 
     def load(key, _opts = {})
-      @mutex.synchronize { fetch_value(key) }
+      @mutex.synchronize { fetch_container(key)&.value }
     end
 
     def key?(key)
@@ -68,13 +68,6 @@ class Circuitbox
       else
         container
       end
-    end
-
-    def fetch_value(key)
-      container = fetch_container(key)
-      return unless container
-
-      container.value
     end
 
     def compact(current_time)


### PR DESCRIPTION
While there are a few changes in this PR most of them were leading up to the last one, which I'll write about first.

If a circuit were to experience a failure right before a time window changing it could be possible for the failure and success counts to be calculated from different time windows. While this could happen with any circuit store it may be more common with stores that take longer to load keys. It's also possible in instances where between `failure_count` and `success_count` calls the system clock were to be modified. The change calculates one time window and uses that value when generating both failure and success keys to be looked up in the circuit store.

Because both keys are being generated in `should_open?` I implemented `values_at` in circuitbox's memory store which should be compatible with moneta adapters. This allows multiple keys to be loaded in one call to the circuit store, which should improve performance on stores that natively support this functionality. Additionally because of the changes I was making to the memory store I removed `fetch_value` and replaced its one use with ruby's safe navigation because that is more performant.

I noticed `error_rate` was always being called in `should_open?` even when the volume threshold was not passed so I moved this calculation into the `passed_rate_threshold?` method.

