### PR TITLE
Rename CircuitBreaker's :cache to :circuit_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Change log
 ### v2.0.0 (unreleased)
+- `Circuitbox::CircuitBreaker`'s `:cache` option has been renamed to `:circuit_store` [\#190](https://github.com/yammer/circuitbox/pull/190)
 - Have the notifiers handle timing rather than circuitbox [\#169](https://github.com/yammer/circuitbox/pull/169)
 - Improve the `Circuitbox.circuit` store when used in multi-threaded cases [\#167](https://github.com/yammer/circuitbox/pull/167)
 - Always emit a runtime metric when running the circuit's block [\#163](https://github.com/yammer/circuitbox/pull/163)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ class ExampleServiceClient
       # the store you want to use to save the circuit state so it can be
       # tracked, this needs to be Moneta compatible, and support increment
       # this overrides what is set in the global configuration
-      cache: Circuitbox::MemoryStore.new,
+      circuit_store: Circuitbox::MemoryStore.new,
 
       # exceeding this rate will open the circuit (checked on failures)
       error_threshold:  50,
@@ -103,7 +103,7 @@ Circuitbox.circuit(:yammer, {
 })
 ```
 
-## Circuit Store (:cache)
+## Circuit Store
 
 Holds all the relevant data to trip the circuit if a given number of requests
 fail in a specified period of time. Circuitbox also supports

--- a/benchmark/object_usage_benchmark.rb
+++ b/benchmark/object_usage_benchmark.rb
@@ -16,13 +16,13 @@ circuits_to_test << Circuitbox::CircuitBreaker.new('circuitbox_memory_store',
                                                    sleep_window: 2,
                                                    time_window: 1,
                                                    exceptions: [StandardError],
-                                                   cache: Circuitbox::MemoryStore.new)
+                                                   circuit_store: Circuitbox::MemoryStore.new)
 
 circuits_to_test << Circuitbox::CircuitBreaker.new('moneta_memory_store',
                                                    sleep_window: 2,
                                                    time_window: 1,
                                                    exceptions: [StandardError],
-                                                   cache: Moneta.new(:Memory, expires: true, threadsafe: true))
+                                                   circuit_store: Moneta.new(:Memory, expires: true, threadsafe: true))
 
 class ObjectUsageBenchmark
   class << self

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -141,7 +141,7 @@ class CircuitBreakerTest < Minitest::Test
 
       @circuit = Circuitbox::CircuitBreaker.new(:yammer,
                                                 exceptions: [Timeout::Error],
-                                                cache: ExpiringCache.new('circuits:yammer:open', true))
+                                                circuit_store: ExpiringCache.new('circuits:yammer:open', true))
     end
 
     def test_key_expiration_closes_circuit


### PR DESCRIPTION
This makes the option passed to a CircuitBreaker align with the naming `default_circuit_store` that can be set in circuitbox's configuration. If a circuit is initialized with the :cache option a warning is output with the new key name.