### PR TITLE
Move Notifier from a class to a module

### DIFF
--- a/lib/circuitbox/notifier/active_support.rb
+++ b/lib/circuitbox/notifier/active_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Circuitbox
-  class Notifier
+  module Notifier
     class ActiveSupport
       def notify(circuit_name, event)
         ::ActiveSupport::Notifications.instrument("#{event}.circuitbox", circuit: circuit_name)

--- a/lib/circuitbox/notifier/null.rb
+++ b/lib/circuitbox/notifier/null.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Circuitbox
-  class Notifier
+  module Notifier
     class Null
       def notify(_circuit_name, _event); end
 


### PR DESCRIPTION
Circuitbox::Notifier doesn't contain any methods and isn't instantiated so it's being changed from a class to a module.