### PR TITLE
Test against Faraday 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,10 @@ end
 
 ## Faraday
 
-Circuitbox ships with [Faraday HTTP client](https://github.com/lostisland/faraday) middleware.
+Circuitbox ships with a [Faraday HTTP client](https://github.com/lostisland/faraday) middleware.
+The versions of faraday the middleware has been tested against is `>= 0.17` through `~> 2.0`.
+The middleware does not support parallel requests through a connections `in_parallel` method.
+
 
 ```ruby
 require 'faraday'

--- a/ci/Gemfile.faraday-0-17
+++ b/ci/Gemfile.faraday-0-17
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'faraday', "~> 2.0"
+gem 'faraday', "~> 0.17"
 
 gemspec(path: '../')

--- a/ci/Gemfile.faraday-1-0
+++ b/ci/Gemfile.faraday-1-0
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'faraday', "~> 0.8.0"
+gem 'faraday', "~> 1.0"
 
 gemspec(path: '../')

--- a/circuitbox.gemspec
+++ b/circuitbox.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '> 2.0'
   spec.add_development_dependency 'excon', '~> 0.71'
-  spec.add_development_dependency 'faraday', ['>= 0.8', '< 2.0']
+  spec.add_development_dependency 'faraday', '>= 0.17'
   spec.add_development_dependency 'gimme', '~> 0.5'
   spec.add_development_dependency 'minitest', '~> 5.14'
   spec.add_development_dependency 'minitest-excludes', '~> 2.0'

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -45,8 +45,6 @@ class Circuitbox
       exceptions: DEFAULT_EXCEPTIONS
     }.freeze
 
-    attr_reader :opts
-
     def initialize(app, opts = {})
       @app = app
       @opts = DEFAULT_OPTIONS.merge(opts)
@@ -70,12 +68,12 @@ class Circuitbox
     private
 
     def call_default_value(response, exception)
-      default_value = opts[:default_value]
+      default_value = @opts[:default_value]
       default_value.respond_to?(:call) ? default_value.call(response, exception) : default_value
     end
 
     def open_circuit?(response)
-      opts[:open_circuit].call(response)
+      @opts[:open_circuit].call(response)
     end
 
     def circuit_open_value(env, service_response, exception)
@@ -83,12 +81,12 @@ class Circuitbox
     end
 
     def circuit(env)
-      identifier = opts[:identifier]
+      identifier = @opts[:identifier]
       id = identifier.respond_to?(:call) ? identifier.call(env) : identifier
 
-      Circuitbox.circuit(id, opts[:circuit_breaker_options])
+      Circuitbox.circuit(id, @opts[:circuit_breaker_options])
     end
   end
 end
 
-Faraday::Middleware.register_middleware circuitbox: Circuitbox::FaradayMiddleware
+Faraday::Middleware.register_middleware(circuitbox: Circuitbox::FaradayMiddleware)

--- a/lib/circuitbox/faraday_middleware.rb
+++ b/lib/circuitbox/faraday_middleware.rb
@@ -34,10 +34,7 @@ class Circuitbox
     }.freeze
 
     DEFAULT_EXCEPTIONS = [
-      # Faraday before 0.9.0 didn't have Faraday::TimeoutError so we default to Faraday::Error::TimeoutError
-      # Faraday >= 0.9.0 defines Faraday::TimeoutError and this can be used for all versions up to 1.0.0 that
-      # also define and raise Faraday::Error::TimeoutError as Faraday::TimeoutError is an ancestor
-      defined?(Faraday::TimeoutError) ? Faraday::TimeoutError : Faraday::Error::TimeoutError,
+      Faraday::TimeoutError,
       RequestFailed
     ].freeze
 

--- a/test.sh
+++ b/test.sh
@@ -23,8 +23,10 @@ run_tests "ci/Gemfile"
 
 run_tests "ci/Gemfile.activesupport"
 
+run_tests "ci/Gemfile.faraday-1-0"
+
 if ruby -e "exit 1 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')"; then
-  run_tests "ci/Gemfile.oldfaraday"
+  run_tests "ci/Gemfile.faraday-0-17"
 else
   cat <<-SKIP
 ############################################

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -81,16 +81,10 @@ class Circuitbox
 
     def test_default_exceptions
       middleware = FaradayMiddleware.new(app)
-
-      faraday_version = Gem::Version.new(Faraday::VERSION).segments
-      faraday_major = faraday_version[0]
-      faraday_minor = faraday_version[1]
-
-      faraday_exception = faraday_major.positive? || faraday_minor > 8 ? Faraday::TimeoutError : Faraday::Error::TimeoutError
       middleware_opts = opts_from(middleware)
       circuit_breaker_options = middleware_opts[:circuit_breaker_options]
 
-      assert_includes circuit_breaker_options[:exceptions], faraday_exception
+      assert_includes circuit_breaker_options[:exceptions], Faraday::TimeoutError
       assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
     end
 

--- a/test/faraday_middleware_test.rb
+++ b/test/faraday_middleware_test.rb
@@ -20,25 +20,28 @@ class Circuitbox
 
     def test_default_identifier
       middleware = FaradayMiddleware.new(app)
+      middleware_opts = opts_from(middleware)
       env = { url: URI('http://yammer.com/') }
 
-      assert_equal 'yammer.com', middleware.opts[:identifier].call(env)
+      assert_equal 'yammer.com', middleware_opts[:identifier].call(env)
     end
 
     def test_default_identifier_no_host
       middleware = FaradayMiddleware.new(app)
+      middleware_opts = opts_from(middleware)
       uri = gimme
       give(uri).host { nil }
       give(uri).to_s { 'yam' }
       env = { url: uri }
 
-      assert_equal 'yam', middleware.opts[:identifier].call(env)
+      assert_equal 'yam', middleware_opts[:identifier].call(env)
     end
 
     def test_overwrite_identifier
       middleware = FaradayMiddleware.new(app, identifier: 'sential')
+      middleware_opts = opts_from(middleware)
 
-      assert_equal 'sential', middleware.opts[:identifier]
+      assert_equal 'sential', middleware_opts[:identifier]
     end
 
     def test_overwrite_default_value_generator_lambda
@@ -78,13 +81,14 @@ class Circuitbox
 
     def test_default_exceptions
       middleware = FaradayMiddleware.new(app)
-      circuit_breaker_options = middleware.opts[:circuit_breaker_options]
 
       faraday_version = Gem::Version.new(Faraday::VERSION).segments
       faraday_major = faraday_version[0]
       faraday_minor = faraday_version[1]
 
       faraday_exception = faraday_major.positive? || faraday_minor > 8 ? Faraday::TimeoutError : Faraday::Error::TimeoutError
+      middleware_opts = opts_from(middleware)
+      circuit_breaker_options = middleware_opts[:circuit_breaker_options]
 
       assert_includes circuit_breaker_options[:exceptions], faraday_exception
       assert_includes circuit_breaker_options[:exceptions], FaradayMiddleware::RequestFailed
@@ -137,7 +141,8 @@ class Circuitbox
 
     def test_overwrite_exceptions
       middleware = FaradayMiddleware.new(app, circuit_breaker_options: { exceptions: [SentialException] })
-      circuit_breaker_options = middleware.opts[:circuit_breaker_options]
+      middleware_opts = opts_from(middleware)
+      circuit_breaker_options = middleware_opts[:circuit_breaker_options]
 
       assert_includes circuit_breaker_options[:exceptions], SentialException
     end
@@ -190,6 +195,12 @@ class Circuitbox
       assert_equal 503, response.status
       assert response.finished?
       refute response.success?
+    end
+
+    private
+
+    def opts_from(middleware)
+      middleware.instance_variable_get(:@opts)
     end
   end
 end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 require "faraday"
 require "circuitbox/faraday_middleware"
 require "rack"


### PR DESCRIPTION
The circuitbox test suite now tests against faraday `~> 0.17`, `~> 1.0`, and `~> 2.0`.

I've dropped support for faraday `< 0.17` with this change. Since faraday isn't a direct dependency of circuitbox it's possible to load the middleware on an older faraday version I won't accept fixes for any versions `< 0.17`.

Another breaking change is the removal of `attr_reader :opts` on `Circuitbox::FaradayMiddleware`. This was only used for tests but making these accessible could lead to options being changed after the middleware was initialized which is something not supported.

Lastly I've removed the in_parallel tests in the faraday middleware integration tests. The tests were never testing that in_parallel failures would cause the circuit to open, only that if the circuit was already closed (which in_parallel requests couldn't do) the in_parallel requests would never be sent.