### PR TITLE
When circuitbox::MemoryStore is used, circuits use the monotonic system clock

### DIFF
--- a/lib/circuitbox/memory_store.rb
+++ b/lib/circuitbox/memory_store.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'memory_store/monotonic_time'
+require_relative 'time_helper/monotonic'
 require_relative 'memory_store/container'
 
 class Circuitbox
   class MemoryStore
-    include MonotonicTime
+    include TimeHelper::Monotonic
 
     def initialize(compaction_frequency: 60)
       @store = {}

--- a/lib/circuitbox/memory_store/container.rb
+++ b/lib/circuitbox/memory_store/container.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'monotonic_time'
+require_relative '../time_helper/monotonic'
 
 class Circuitbox
   class MemoryStore
     class Container
-      include MonotonicTime
+      include TimeHelper::Monotonic
 
       attr_accessor :value
 

--- a/lib/circuitbox/time_helper/monotonic.rb
+++ b/lib/circuitbox/time_helper/monotonic.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Circuitbox
-  class MemoryStore
-    module MonotonicTime
+  module TimeHelper
+    module Monotonic
       module_function
 
       def current_second

--- a/lib/circuitbox/time_helper/real.rb
+++ b/lib/circuitbox/time_helper/real.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Circuitbox
+  module TimeHelper
+    module Real
+      module_function
+
+      def current_second
+        ::Time.now.to_i
+      end
+    end
+  end
+end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -459,6 +459,33 @@ class CircuitBreakerTest < Minitest::Test
     end
   end
 
+  def test_time_class_can_be_overridden
+    # this wouldn't work since Time doesn't have a `current_second` method,
+    # but it's to test that time_class can be overridden
+    circuit = Circuitbox::CircuitBreaker.new(:yammer,
+                                             exceptions: [StandardError],
+                                             circuit_store: Circuitbox::MemoryStore.new,
+                                             time_class: Time)
+
+    assert_equal Time, circuit.time_class
+  end
+
+  def test_time_class_defaults_to_realtime_when_not_circuitbox_memorystore
+    circuit = Circuitbox::CircuitBreaker.new(:yammer,
+                                             exceptions: [StandardError],
+                                             circuit_store: Moneta.new(:Memory, expires: true))
+
+    assert_equal Circuitbox::TimeHelper::Real, circuit.time_class
+  end
+
+  def test_time_class_defaults_to_monotonic_when_circuitbox_memorystore
+    circuit = Circuitbox::CircuitBreaker.new(:yammer,
+                                             exceptions: [StandardError],
+                                             circuit_store: Circuitbox::MemoryStore.new)
+
+    assert_equal Circuitbox::TimeHelper::Monotonic, circuit.time_class
+  end
+
   class Notifications < Minitest::Test
     def setup
       Circuitbox.configure do |config|

--- a/test/time_helper/monotonic_test.rb
+++ b/test/time_helper/monotonic_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+require 'circuitbox/time_helper/monotonic'
+
+class TimeHelperMonotonicTest < Minitest::Test
+  class MonotonicIncluded
+    include Circuitbox::TimeHelper::Monotonic
+  end
+
+  def test_current_second_is_instance_method_when_included
+    assert_respond_to(MonotonicIncluded.new, :current_second)
+  end
+
+  def test_current_second_can_be_directly_called
+    assert_respond_to(Circuitbox::TimeHelper::Monotonic, :current_second)
+  end
+
+  def test_current_second_uses_the_systems_monotonic_clock
+    Process.expects(:clock_gettime).with(Process::CLOCK_MONOTONIC, :second)
+
+    Circuitbox::TimeHelper::Monotonic.current_second
+  end
+end

--- a/test/time_helper/real_test.rb
+++ b/test/time_helper/real_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'circuitbox/time_helper/real'
+
+class TimeHelperRealTest < Minitest::Test
+  class RealIncluded
+    include Circuitbox::TimeHelper::Real
+  end
+
+  def test_current_second_is_instance_method_when_included
+    assert_respond_to(RealIncluded.new, :current_second)
+  end
+
+  def test_current_second_can_be_directly_called
+    assert_respond_to(Circuitbox::TimeHelper::Real, :current_second)
+  end
+
+  def test_current_second_uses_time_now
+    now = gimme
+    give(now).to_i { 5 }
+    Time.expects(:now).returns(now)
+
+    assert_equal 5, Circuitbox::TimeHelper::Real.current_second
+  end
+end


### PR DESCRIPTION
Add monotonic and real time helpers allowing circuit breakers to utilize the monotonic system clock when using circuitbox's memory store

Unified the monotonic helper across Circuitbox::MemoryStore and Circuitbox::CircuitBreaker. Monotonic time helper is only used when the circuit_store is a Circuitbox::MemoryStore, all other stores use the Real (`Time.now.to_i`) time helper.