### PR TITLE
wrong argument type true (expected String) (TypeError)

### DIFF
--- a/lib/circuitbox/circuit_breaker.rb
+++ b/lib/circuitbox/circuit_breaker.rb
@@ -190,8 +190,8 @@ class Circuitbox
     end
 
     def trip
-      @circuit_store.store(@open_storage_key, true, expires: option_value(:sleep_window))
-      @circuit_store.store(@half_open_storage_key, true)
+      @circuit_store.store(@open_storage_key, 'true', expires: option_value(:sleep_window))
+      @circuit_store.store(@half_open_storage_key, 'true')
     end
 
     def close!


### PR DESCRIPTION
Currently this issue was raised when the `trip` method was invoked:

`in: wrong argument type true (expected String) (TypeError)`

Here is the backtrace:

```
/usr/local/bundle/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/quoting.rb:18:in `escape_bytea'
/usr/local/bundle/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/quoting.rb:18:in `escape_bytea'
/usr/local/bundle/gems/moneta-1.6.0/lib/moneta/adapters/activerecord.rb:292:in `encode'
/usr/local/bundle/gems/moneta-1.6.0/lib/moneta/adapters/activerecord.rb:91:in `block in store'
/usr/local/bundle/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:227:in `with_connection'
/usr/local/bundle/gems/moneta-1.6.0/lib/moneta/adapters/activerecord.rb:21:in `with_connection'
/usr/local/bundle/gems/moneta-1.6.0/lib/moneta/adapters/activerecord.rb:90:in `store'
(irb):24:in `<main>'
/usr/local/bundle/gems/irb-1.13.1/lib/irb/workspace.rb:121:in `eval'
/usr/local/bundle/gems/irb-1.13.1/lib/irb/workspace.rb:121:in `evaluate'
/usr/local/bundle/gems/irb-1.13.1/lib/irb/context.rb:633:in `evaluate_expression'
/usr/local/bundle/gems/irb-1.13.1/lib/irb/context.rb:600:in `evaluate'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1049:in `block (2 levels) in eval_input'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1380:in `signal_status'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1041:in `block in eval_input'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1120:in `block in each_top_level_statement'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1117:in `loop'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1117:in `each_top_level_statement'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1040:in `eval_input'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1021:in `block in run'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1020:in `catch'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:1020:in `run'
/usr/local/bundle/gems/irb-1.13.1/lib/irb.rb:904:in `start'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/commands/console/console_command.rb:78:in `start'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/commands/console/console_command.rb:16:in `start'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/commands/console/console_command.rb:106:in `perform'
/usr/local/bundle/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
/usr/local/bundle/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/command/base.rb:178:in `invoke_command'
/usr/local/bundle/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/command/base.rb:73:in `perform'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/command.rb:71:in `block in invoke'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/command.rb:149:in `with_argv'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/command.rb:69:in `invoke'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/commands.rb:18:in `<main>'
/usr/local/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/usr/local/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/usr/local/bundle/gems/zeitwerk-2.6.15/lib/zeitwerk/kernel.rb:34:in `require'
/app/bin/rails:5:in `<main>'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/commands/rails.rb:6:in `load'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/commands/rails.rb:6:in `call'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/command_wrapper.rb:38:in `call'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application.rb:226:in `block in serve'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/fork_tracker.rb:20:in `block in fork'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/fork_tracker.rb:18:in `fork'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/fork_tracker.rb:18:in `fork'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application.rb:190:in `serve'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application.rb:153:in `block in run'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application.rb:147:in `loop'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application.rb:147:in `run'
/usr/local/bundle/gems/spring-4.2.1/lib/spring/application/boot.rb:25:in `<top (required)>'
<internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'

```

Here's how the circuit was configured:

```
Circuitbox::CircuitBreaker.new(
  name, {
    # exceptions circuitbox tracks for counting failures (required)
    exceptions:       [StandardError],

    # seconds the circuit stays open once it has passed the error threshold
    sleep_window:     90,

    # length of interval (in seconds) over which it calculates the error rate
    time_window:      3600,

    # number of requests within `time_window` seconds before it calculates error
    # rates (checked on failures)
    volume_threshold: 4,

    # Customized notifier overrides the default and what is set in the global
    # configuration
    notifier:         Circuitbox::Notifier::ActiveSupport.new,

    # the store you want to use to save the circuit state so it can be
    # tracked, this needs to be Moneta compatible, and support increment
    # this overrides what is set in the global configuration
    circuit_store:    Moneta::Adapters::ActiveRecord.new,

    # exceeding this rate will open the circuit (checked on failures)
    error_threshold:  3
  }
)
```