### PR TITLE
Clarify Moneta integration in Circuit Store documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,18 @@ Circuitbox.circuit(:yammer, {
 ## Circuit Store
 
 Holds all the relevant data to trip the circuit if a given number of requests
-fail in a specified period of time. Circuitbox also supports
-[Moneta](https://github.com/moneta-rb/moneta). As moneta is not a dependency of circuitbox
-it needs to be loaded prior to use. There are a lot of moneta stores to choose from but
-some pre-requisits need to be satisfied first:
+fail in a specified period of time. By default, Circuitbox uses an in-memory
+store, but it also supports [Moneta](https://github.com/moneta-rb/moneta) for
+alternative storage options. To use Moneta, add it to your project dependencies.
 
-- Needs to support increment, this is true for most but not all available stores.
-- Needs to support expiry.
-- Needs to support bulk read.
-- Needs to support concurrent access if you share them. For example sharing a
-  KyotoCabinet store across process fails because the store is single writer
-  multiple readers, and all circuits sharing the store need to be able to write.
+When using a Moneta store, ensure it:
+
+- Supports increment operations (true for most, but not all available stores)
+- Supports key expiry
+- Supports bulk read operations
+- Supports concurrent access if shared between processes (For example,
+  KyotoCabinet is single-writer/multiple-readers, which can cause issues when
+  multiple circuits need write access)
 
 
 ## Notifications


### PR DESCRIPTION
I found the Circuit Store documentation about Moneta integration confusing,  particularly the statement that Moneta "needs to be loaded prior to use."  After testing, I confirmed that there's no specific loading order requirement  between Circuitbox and Moneta.

This commit updates the documentation to:
- Remove potentially confusing language about loading requirements
- Explicitly state that Circuitbox uses an in-memory store by default
- Present Moneta as an optional alternative storage option
- Preserve the existing Moneta compatibility requirements

These changes should help other developers better understand how to integrate  Moneta with Circuitbox if they choose to use an alternative store.